### PR TITLE
Debug overlay is brought up by calls to any of the dbg_* functions

### DIFF
--- a/Manual/contents/GameMaker_Language/GML_Overview/Data_Types.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Data_Types.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>Data Types</h1>
+  <h1><span data-field="title" data-format="default">Data Types</span></h1>
   <p>In previous section we covered <a href="Variables_And_Variable_Scope.htm">variables and their scoping rules</a> but little has been said about the different <b>data types</b> that a variable can store. Therefore this section explains the different types and what they can be used for.</p>
   <p>Before continuing, let&#39;s just briefly explain what we mean by &quot;data types&quot;. When you create a variable it can be used to hold information, and when you call a function, it can also stored returned information. However this information can come in various &quot;flavours&quot; - for example, it can be a <em>real number</em> or it can be a <em>string</em>. These different types of values being used are called <b>data types</b> and when using the GameMaker Language they can be any of the following:</p>
   <p><a class="dropspot" data-rhwidget="DropSpot" data-target="drop-down1" href="#">Real Numbers</a></p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/The_Debug_Overlay.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/The_Debug_Overlay.htm
@@ -17,7 +17,7 @@
   <h1><span data-field="title" data-format="default">The Debug Overlay</span></h1>
   <p><span data-field="title" data-format="default">The Debug Overlay</span> is an in-game overlay that displays various realtime debug information about your game.</p>
   <p>It includes the following three windows by default: <strong>FPS</strong> (open by default), <strong>Log</strong>, and <strong>Audio</strong>. Additionally, it displays the <span data-keyref="GameMaker Name">GameMaker</span> version in the top-right corner, along with the version and name of the project.</p>
-  <p><span data-field="title" data-format="default">The Debug Overlay</span> can be accessed using the functions <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span> and <span class="inline3_func"><a data-xref="{title}" href="show_debug_log.htm">show_debug_log</a></span>, the first opens the overlay with the <strong>FPS</strong> window open, the second with the <strong>Log</strong> window open.</p>
+  <p><span data-field="title" data-format="default">The Debug Overlay</span> can be accessed using the functions <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span> and <span class="inline3_func"><a data-xref="{title}" href="show_debug_log.htm">show_debug_log</a></span>, the first opens the overlay with the <strong>FPS</strong> window open, the second with the <strong>Log</strong> window open. It is also opened by the <span class="inline3_func">dbg_*</span> functions.</p>
   <p>You can define your own, custom debug views in <span data-field="title" data-format="default">The Debug Overlay</span> using <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span>. Debug views can have sections added to them using <span class="inline3_func"><a data-xref="{title}" href="dbg_section.htm">dbg_section</a></span>, which you can add controls to such as sliders, string input boxes, etc. These allow you to change the values of variables through references created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span>. The <strong>DebugView</strong> option under the <strong>Debug</strong> menu determines if custom views are visible. All debug views are listed under the <strong>Views</strong> menu and can have their visibility toggled here.</p>
   <p><img class="center" height="381" src="../../../assets/Images/Scripting_Reference/GML/Reference/Debug/debug_overlay_1.png" width="1322" /></p>
   <h2 id="debug">Debug</h2>
@@ -97,7 +97,7 @@
   <h3 id="creating_debug_views">Creating Debug Views</h3>
   <p>A custom<em> debug view</em> is created using <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span>: </p>
   <p class="code">custom_dbgview = dbg_view(&quot;Custom Debug View&quot;, true);</p>
-  <p>The first argument is its name, the second is its visibility setting when <span data-field="title" data-format="default">The Debug Overlay</span> is opened. Optional parameters can be passed to customise its position and size.</p>
+  <p>The first argument is its name, the second is its visibility setting. Optional parameters can be passed to customise its position and size.</p>
   <p>Within debug views, you create <em>sections</em> using <span class="inline3_func"><a data-xref="{title}" href="dbg_section.htm">dbg_section</a></span>: </p>
   <p class="code">custom_section = dbg_section(&quot;Custom Section&quot;);</p>
   <p>To these sections you add <em>controls</em> that display and/or modify the value that they&#39;re linked to via a reference created with <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span>.</p>
@@ -115,9 +115,7 @@
     dbg_button(&quot;Button1&quot;, ref);
   </p>
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> A debug control created before a section is created will be added to a new section named <span data-keyref="DebugSection_Name_Default">&quot;Default&quot;</span>. A debug section that&#39;s created before a debug view is created will be added to a debug view <span data-keyref="DebugView_Name_Default">&quot;Default&quot;</span>.</p>
-  <p>Lastly, to show <span data-field="title" data-format="default">The Debug Overlay</span> with the views that you defined, call <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span> with the first parameter <span class="inline2">enable</span> set to <span class="inline2">true</span>: </p>
-  <p class="code">show_debug_overlay(true);</p>
-  <p>The above lines of code will show the following window in <span data-field="title" data-format="default">The Debug Overlay</span>: </p>
+  <p>The above lines of code will show the<span data-field="title" data-format="default">The Debug Overlay</span> with the following window added to it: </p>
   <p><img class="center" src="../../../assets/Images/Scripting_Reference/GML/Reference/Debug/debug_overlay_custom_debug_view.png" /></p>
   <h2 id="system">System</h2>
   <p>This menu contains two settings related to the debug overlay: </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_button.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_button.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <h1><span data-field="title" data-format="default">dbg_button</span></h1>
-  <p>This function creates a button control within the current debug section. Clicking the button executes a <span data-keyref="Type_Function"><a href="GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Function</a></span>.</p>
+  <p>This function creates a button control within the current debug section. Clicking the button executes a <span data-keyref="Type_Function"><a href="../../../../GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Function</a></span>.</p>
   <p>The current debug section is the one last created using <span class="inline3_func"><a data-xref="{title}" href="dbg_section.htm">dbg_section</a></span>.</p>
   <p> </p>
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Single_Column.hts"> </div>
@@ -36,22 +36,22 @@
       </tr>
       <tr>
         <td>label</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td>The text label to show next to the button</td>
       </tr>
       <tr>
         <td>ref</td>
-        <td><span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span> or <span data-keyref="Type_Function_Script"><a href="GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Script Function</a></span> or <span data-keyref="Type_Function"><a href="GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Function</a></span></td>
-        <td>A reference to a <span data-keyref="Type_Function"><a href="GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Function</a></span> or <span data-keyref="Type_Function_Script"><a href="GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Script Function</a></span> created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span> or a function</td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span> or <span data-keyref="Type_Function_Script"><a href="../../../../GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Script Function</a></span> or <span data-keyref="Type_Function"><a href="../../../../GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Function</a></span></td>
+        <td>A reference to a <span data-keyref="Type_Function"><a href="../../../../GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Function</a></span> or <span data-keyref="Type_Function_Script"><a href="../../../../GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Script Function</a></span> created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span> or a function</td>
       </tr>
       <tr>
         <td>width</td>
-        <td><span data-keyref="Type_Real"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The width of the button in pixels</td>
       </tr>
       <tr>
         <td>height</td>
-        <td><span data-keyref="Type_Real"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The height of the button in pixels</td>
       </tr>
     </tbody>
@@ -62,9 +62,8 @@
   <p> </p>
   <h4>Example:</h4>
   <p class="code_heading">Create Event</p>
-  <p class="code"><span data-field="title" data-format="default">dbg_button</span>(&quot;Click me!&quot;, function() {show_debug_message(&quot;Clicked the button!&quot;});<br />
-    show_debug_overlay(true);</p>
-  <p>The above code creates a button control in an <a href="../Asset_Management/Objects/Objects.htm">object</a>&#39;s Create event using <span class="inline3_func"><span data-field="title" data-format="default">dbg_button</span></span>. Since no calls are made to <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span> or <span class="inline3_func"><a data-xref="{title}" href="dbg_section.htm">dbg_section</a></span>, the button is added to a new debug section named <span data-keyref="DebugSection_Name_Default">&quot;Default&quot;</span> in a new debug view named <span data-keyref="DebugView_Name_Default">&quot;Default&quot;</span>. Clicking the button calls a function that shows a debug message using <span class="inline3_func"><a data-xref="{title}" href="show_debug_message.htm">show_debug_message</a></span>. <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> is then shown using <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span>, showing the newly created debug view with the button in it.</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_button</span>(&quot;Click me!&quot;, function() {show_debug_message(&quot;Clicked the button!&quot;});</p>
+  <p>The above code creates a button control in an <a href="../Asset_Management/Objects/Objects.htm">object</a>&#39;s Create event using <span class="inline3_func"><span data-field="title" data-format="default">dbg_button</span></span>. Since no calls are made to <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span> or <span class="inline3_func"><a data-xref="{title}" href="dbg_section.htm">dbg_section</a></span>, the button is added to a new debug section named <span data-keyref="DebugSection_Name_Default">&quot;Default&quot;</span> in a new debug view named <span data-keyref="DebugView_Name_Default">&quot;Default&quot;</span>. Clicking the button calls a function that shows a debug message using <span class="inline3_func"><a data-xref="{title}" href="show_debug_message.htm">show_debug_message</a></span>.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_checkbox.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_checkbox.htm
@@ -16,7 +16,7 @@
 <body>
   <h1><span data-field="title" data-format="default">dbg_checkbox</span></h1>
   <p>This function creates a checkbox control within the current debug section.</p>
-  <p>The checkbox takes the value of a <span data-keyref="Type_Bool"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span> variable. Clicking it toggles the variable.</p>
+  <p>The checkbox takes the value of a <span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span> variable. Clicking it toggles the variable.</p>
   <p>The current debug section is the one last created using <span class="inline3_func"><a data-xref="{title}" href="dbg_section.htm">dbg_section</a></span>.</p>
   <p> </p>
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Two_Columns.hts"> </div>
@@ -37,12 +37,12 @@
       </tr>
       <tr>
         <td>ref</td>
-        <td><span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
-        <td>A reference to a <span data-keyref="Type_Bool"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span> variable created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span></td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
+        <td>A reference to a <span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span> variable created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span></td>
       </tr>
       <tr>
         <td>label</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> A label to display next to the checkbox</td>
       </tr>
     </tbody>
@@ -56,12 +56,9 @@
   <p class="code">toggle = false;<br />
     <br />
     var _ref_to_toggle = ref_create(self, &quot;toggle&quot;);<br />
-    <span data-field="title" data-format="default">dbg_checkbox</span>(_ref_to_toggle, &quot;The Toggle Switch&quot;);<br />
-    <br />
-    show_debug_overlay(true);
+    <span data-field="title" data-format="default">dbg_checkbox</span>(_ref_to_toggle, &quot;The Toggle Switch&quot;);
   </p>
   <p>The code above sets a boolean variable <span class="inline2">toggle</span> in the Create event. It creates a reference to the variable using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span>, stores it in a local variable <span class="inline2">_ref_to_toggle</span> and passes that to <span class="inline3_func"><span data-field="title" data-format="default">dbg_checkbox</span></span>. Since no calls were made to <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span> or <span class="inline3_func"><a data-xref="{title}" href="dbg_section.htm">dbg_section</a></span>, a new view <span data-keyref="DebugView_Name_Default">&quot;Default&quot;</span> and a new section <span data-keyref="DebugSection_Name_Default">&quot;Default&quot;</span> are created that the checkbox control is added to. The checkbox will show a text label &quot;The Toggle Switch&quot; next to it.</p>
-  <p>Finally, <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> is shown by calling <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span> with the first parameter set to <span class="inline2">true</span> to bring up the new debug view and the checkbox.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_colour.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_colour.htm
@@ -29,7 +29,7 @@
 <body>
   <h1><span data-field="title" data-format="default">dbg_colour</span></h1>
   <p>This function creates a colour control within the current debug section.</p>
-  <p>The control takes the value of a <span data-keyref="Type_Constant_Colour"><a href="GameMaker_Language/GML_Reference/Drawing/Colour_And_Alpha/Colour_And_Alpha.htm" target="_blank">Colour</a></span> variable and shows the R, G and B component: </p>
+  <p>The control takes the value of a <span data-keyref="Type_Constant_Colour"><a href="../../../../GameMaker_Language/GML_Reference/Drawing/Colour_And_Alpha/Colour_And_Alpha.htm" target="_blank">Colour</a></span> variable and shows the R, G and B component: </p>
   <p><img class="center" src="../../../assets/Images/Scripting_Reference/GML/Reference/Debug/debug_overlay_colour_control.png" />You can change the R, G and B value by double-clicking on the value and entering a new value. You can also click the square on the right that shows the colour to bring up a colour picker dialog that selects a new colour.</p>
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> The value is an RGB colour value, <em>without</em> an alpha component.</p>
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Two_Columns.hts"> </div>
@@ -50,12 +50,12 @@
       </tr>
       <tr>
         <td>ref</td>
-        <td><span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
-        <td>A reference created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span> to a <span data-keyref="Type_Constant_Colour"><a href="GameMaker_Language/GML_Reference/Drawing/Colour_And_Alpha/Colour_And_Alpha.htm" target="_blank">Colour</a></span> variable</td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
+        <td>A reference created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span> to a <span data-keyref="Type_Constant_Colour"><a href="../../../../GameMaker_Language/GML_Reference/Drawing/Colour_And_Alpha/Colour_And_Alpha.htm" target="_blank">Colour</a></span> variable</td>
       </tr>
       <tr>
         <td>label</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> A label to show next to the colour control</td>
       </tr>
     </tbody>
@@ -68,12 +68,11 @@
   <p class="code_heading">Create Event</p>
   <p class="code">my_view = dbg_view($&quot;Settings for {id}&quot;, true);<br />
     my_section = dbg_section(&quot;Colours&quot;);<br />
-    dbg_colour(ref_create(self, &quot;image_blend&quot;), &quot;Blend Colour&quot;);<br />
-    show_debug_overlay(true);</p>
+    dbg_colour(ref_create(self, &quot;image_blend&quot;), &quot;Blend Colour&quot;);</p>
   <p class="code_heading">Clean Up Event</p>
   <p class="code">dbg_section_delete(my_section);<br />
     dbg_view_delete(my_view);</p>
-  <p>The code above is added to an <a href="../Asset_Management/Objects/Objects.htm">object</a>&#39;s Create event. Every <a href="../../../Quick_Start_Guide/Objects_And_Instances.htm">instance</a> of this object that executes the code creates a new debug view using <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span>, stores it in an instance variable <span class="inline2">my_view</span> and adds a section named &quot;Colours&quot; to it using <span class="inline3_func"><a data-xref="{title}" href="dbg_section.htm">dbg_section</a></span>, stored in a variable <span class="inline2">my_section</span>. Each of them then adds a colour control using <span class="inline3_func"><span data-field="title" data-format="default">dbg_colour</span></span> that changes that instance&#39;s <span class="inline2"><a data-xref="{title}" href="../Asset_Management/Sprites/Sprite_Instance_Variables/image_blend.htm">image_blend</a></span> colour, and finally shows <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> by calling <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span> with <span class="inline2">enable</span> set to <span class="inline2">true</span>.</p>
+  <p>The code above is added to an <a href="../Asset_Management/Objects/Objects.htm">object</a>&#39;s Create event. Every <a href="../../../Quick_Start_Guide/Objects_And_Instances.htm">instance</a> of this object that executes the code creates a new debug view using <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span>, stores it in an instance variable <span class="inline2">my_view</span> and adds a section named &quot;Colours&quot; to it using <span class="inline3_func"><a data-xref="{title}" href="dbg_section.htm">dbg_section</a></span>, stored in a variable <span class="inline2">my_section</span>. Each of them then adds a colour control using <span class="inline3_func"><span data-field="title" data-format="default">dbg_colour</span></span> that changes that instance&#39;s <span class="inline2"><a data-xref="{title}" href="../Asset_Management/Sprites/Sprite_Instance_Variables/image_blend.htm">image_blend</a></span> colour.</p>
   <p>In the Clean Up event, every instance of this object deletes its debug view and section that it created (<span class="inline2">my_view</span> and <span class="inline2">my_section</span> respectively).</p>
   <p> </p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_drop_down.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_drop_down.htm
@@ -35,17 +35,17 @@
       </tr>
       <tr>
         <td>ref</td>
-        <td><span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
         <td>A reference to the variable, created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span></td>
       </tr>
       <tr>
         <td>specifier</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td>A comma-delimited string listing the options and, optionally, the integer value to use (e.g. <span class="inline2">&quot;Zero,One:10,Two:20&quot;</span>)</td>
       </tr>
       <tr>
         <td>label</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> A label to show next to the dropdown</td>
       </tr>
     </tbody>
@@ -58,10 +58,9 @@
   <p class="code_heading">Create Event</p>
   <p class="code">difficulty = 1;<br />
     var _ref = ref_create(self, &quot;difficulty&quot;);<br />
-    <span data-field="title" data-format="default">dbg_drop_down</span>(_ref, &quot;Easy:0,Normal:1,Hard:2,Impossible:3&quot;);<br />
-    show_debug_overlay(true);
+    <span data-field="title" data-format="default">dbg_drop_down</span>(_ref, &quot;Easy:0,Normal:1,Hard:2,Impossible:3&quot;);
   </p>
-  <p>The code above first set an instance variable <span class="inline2">difficulty</span> that stores the game&#39;s difficulty level. It creates a reference to the variable using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span> and creates a dropdown control using <span class="inline3_func"><span data-field="title" data-format="default">dbg_drop_down</span></span> to change the variable through that reference. The <span class="inline2">specifier</span> lists the four difficulty levels as <span class="inline2">&quot;Easy:0,Normal:1,Hard:2,Impossible:3&quot;</span>. Finally, <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> is shown using a call to <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span>.</p>
+  <p>The code above first set an instance variable <span class="inline2">difficulty</span> that stores the game&#39;s difficulty level. It creates a reference to the variable using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span> and creates a dropdown control using <span class="inline3_func"><span data-field="title" data-format="default">dbg_drop_down</span></span> to change the variable through that reference. The <span class="inline2">specifier</span> lists the four difficulty levels as <span class="inline2">&quot;Easy:0,Normal:1,Hard:2,Impossible:3&quot;</span>.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_same_line.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_same_line.htm
@@ -34,12 +34,9 @@
   <p class="code">dbg_view(&quot;Custom View&quot;, true);<br />
     dbg_button(&quot;Button1&quot;, function() {show_debug_message(&quot;Clicked Button1&quot;);});<br />
     <span data-field="title" data-format="default">dbg_same_line</span>();<br />
-    dbg_button(&quot;Button2&quot;, function() {show_debug_message(&quot;Clicked Button2&quot;);});<br />
-    show_debug_overlay(true);
+    dbg_button(&quot;Button2&quot;, function() {show_debug_message(&quot;Clicked Button2&quot;);});
   </p>
-  <p>The code above first defines a new debug view using <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span> and sets it to be visible. It then adds two buttons directly to the debug view, meaning they will be added to a new debug section <span data-keyref="DebugSection_Name_Default">&quot;Default&quot;</span>.</p>
-  <p>Next, two button controls are added using <span class="inline3_func"><a data-xref="{title}" href="dbg_button.htm">dbg_button</a></span>, which will be placed on the same line because of the <span class="inline3_func"><span data-field="title" data-format="default">dbg_same_line</span></span> between the two function calls. Both functions show a basic debug message.</p>
-  <p>Finally, a call to <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span> shows <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a>, with the new debug view &quot;Custom View&quot; visible, as set before.</p>
+  <p>The code above first defines a new debug view using <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span> and sets it to be visible. It then adds two buttons directly to the debug view, meaning they will be added to a new debug section <span data-keyref="DebugSection_Name_Default">&quot;Default&quot;</span>. After that, two button controls are added using <span class="inline3_func"><a data-xref="{title}" href="dbg_button.htm">dbg_button</a></span>, which will be placed on the same line because of the <span class="inline3_func"><span data-field="title" data-format="default">dbg_same_line</span></span> between the two function calls. Both functions show a basic debug message.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_section.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_section.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <h1><span data-field="title" data-format="default">dbg_section</span></h1>
-  <p>This function creates a section in the active debug view. The active debug view is the one last created using <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span>.</p>
+  <p>This function creates a section in the debug view last added with <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span> and sh<span>ows it in <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a></span>.</p>
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> If no debug view is active then the section is added to a new debug view named <span data-keyref="DebugView_Name_Default">&quot;Default&quot;</span>.</p>
   <h3>Usage Notes</h3>
   <ul class="Disc">
@@ -41,21 +41,20 @@
       </tr>
       <tr>
         <td>name</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td>The name of the new debug section</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Pointer_DebugSection"><a href="GameMaker_Language/GML_Reference/Debugging/dbg_section.htm" target="_blank">Pointer.DebugSection</a></span></p>
+  <p class="code"><span data-keyref="Type_Pointer_DebugSection"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/dbg_section.htm" target="_blank">Pointer.DebugSection</a></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">dbg_view(&quot;CustomDebugView&quot;);<br />
-    <span data-field="title" data-format="default">dbg_section</span>(&quot;Player Variables&quot;);<br />
-    show_debug_<span class="misspell-word">overlay(true);</span>
+    <span data-field="title" data-format="default">dbg_section</span>(&quot;Player Variables&quot;);
   </p>
-  <p>The code above first creates a new debug view using <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span> named &quot;CustomDebugView&quot; and adds a new section &quot;Player Variables&quot; to it using <span class="inline3_func"><span data-field="title" data-format="default">dbg_section</span></span>. It then opens <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> with a call to <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span>.</p>
+  <p>The code above creates a new debug view using <span class="inline3_func"><a data-xref="{title}" href="dbg_view.htm">dbg_view</a></span> named &quot;CustomDebugView&quot; and adds a new section &quot;Player Variables&quot; to it using <span class="inline3_func"><span data-field="title" data-format="default">dbg_section</span></span>.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_slider.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_slider.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <h1><span data-field="title" data-format="default">dbg_slider</span></h1>
-  <p>This function creates a slider control for a <span data-keyref="Type_Real"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span> value within the current debug section.</p>
+  <p>This function creates a slider control for a <span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span> value within the current debug section.</p>
   <p>You can optionally provide a minimum and maximum value for the slider.</p>
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Two_Columns.hts"> </div>
   <p> </p>
@@ -35,22 +35,22 @@
       </tr>
       <tr>
         <td>ref</td>
-        <td><span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
-        <td>A reference to a <span data-keyref="Type_Real"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span> value, created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span></td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
+        <td>A reference to a <span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span> value, created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span></td>
       </tr>
       <tr>
         <td>minimum</td>
-        <td><span data-keyref="Type_Real"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The minimum value that the slider can have</td>
       </tr>
       <tr>
         <td><span>maximum</span></td>
-        <td><span data-keyref="Type_Real"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The maximum value that the slider can have</td>
       </tr>
       <tr>
         <td><span><span>label</span></span></td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The label to show next to the slider</td>
       </tr>
     </tbody>
@@ -62,11 +62,9 @@
   <h4>Example:</h4>
   <p class="code_heading">Create Event</p>
   <p class="code">my_var = 7;<br />
-    <span data-field="title" data-format="default">dbg_slider</span>(ref_create(self, &quot;my_var&quot;), 0, 10);<br />
-    show_debug_overlay(true);
+    <span data-field="title" data-format="default">dbg_slider</span>(ref_create(self, &quot;my_var&quot;), 0, 10);
   </p>
-  <p>The above code is executed in an <a href="../Asset_Management/Objects/Objects.htm">object</a>&#39;s Create event, or any other event that isn&#39;t performed continuously. First, an <a href="../../GML_Overview/Variables/Instance_Variables.htm">instance variable</a> <span class="inline2">my_var</span> is set. Then, a slider control is created using <span class="inline3_func"><span data-field="title" data-format="default">dbg_slider</span></span>. It receives a reference to the variable, returned by <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span>, and values of 0 and 10 for the <span class="inline2">minimum</span> and <span class="inline2">maximum</span> parameters.</p>
-  <p>Finally, the call to <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span> brings up <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> with a custom debug view that contains the slider. Dragging this slider changes the value of the instance&#39;s <span class="inline2">my_var</span> variable.</p>
+  <p>The above code is executed in an <a href="../Asset_Management/Objects/Objects.htm">object</a>&#39;s Create event, or any other event that isn&#39;t performed continuously. First, an <a href="../../GML_Overview/Variables/Instance_Variables.htm">instance variable</a> <span class="inline2">my_var</span> is set. Then, a slider control is created using <span class="inline3_func"><span data-field="title" data-format="default">dbg_slider</span></span>. It receives a reference to the variable, returned by <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span>, and values of 0 and 10 for the <span class="inline2">minimum</span> and <span class="inline2">maximum</span> parameters. Dragging the slider changes the value of the instance&#39;s <span class="inline2">my_var</span> variable.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_sprite.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_sprite.htm
@@ -20,7 +20,7 @@
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Two_Columns.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_sprite</span>(<span>sprite_ref, <span><span class="misspell-word">image_index_ref</span>[, label]</span></span>);</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_sprite</span>(<span>sprite_ref, <span>image_index_ref[, label]</span></span>);</p>
   <table>
     <colgroup>
       <col />
@@ -35,17 +35,17 @@
       </tr>
       <tr>
         <td>sprite_ref</td>
-        <td><span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
         <td>A reference to a variable holding a sprite index, created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span></td>
       </tr>
       <tr>
         <td>image_index_ref</td>
-        <td><span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
         <td>A reference to a variable that holds the image index to show, created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span></td>
       </tr>
       <tr>
         <td>label</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The label to display next to the sprite view</td>
       </tr>
     </tbody>
@@ -58,12 +58,11 @@
   <p class="code_heading">Create Event</p>
   <p class="code">ref_to_sprite = ref_create(self, &quot;sprite_index&quot;);<br />
     ref_to_image_index = ref_create(self, &quot;image_index&quot;);<br />
-    <span data-field="title" data-format="default">dbg_sprite</span>(ref_to_sprite, ref_to_image_index);<br />
-    show_debug_overlay(true);
+    <span data-field="title" data-format="default">dbg_sprite</span>(ref_to_sprite, ref_to_image_index);
   </p>
   <p>The above code sets up a basic sprite view for an instance&#39;s sprite. The code is added to an event that is only executed once, e.g. the Create event.</p>
   <p>First, two references are created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span>: one to the current instance&#39;s <span class="inline2"><a data-xref="{title}" href="../Asset_Management/Sprites/Sprite_Instance_Variables/sprite_index.htm">sprite_index</a></span> variable (stored in <span class="inline2">ref_to_sprite</span>), the other to the instance&#39;s <span class="inline2"><a data-xref="{title}" href="../Asset_Management/Sprites/Sprite_Instance_Variables/image_index.htm">image_index</a></span> variable (stored in <span class="inline2">ref_to_image_index</span>). Next, the sprite view is created using <span class="inline3_func"><span data-field="title" data-format="default">dbg_sprite</span></span>, with arguments the two references created before.</p>
-  <p>Finally, <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> is shown by calling <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span> with the <span class="inline2">enable</span> parameter set to <span class="inline2">true</span>. The sprite&#39;s frame will change based on the value of <span class="inline2"><a data-xref="{title}" href="../Asset_Management/Sprites/Sprite_Instance_Variables/image_index.htm">image_index</a></span>, and so is drawn animated in the sprite view. The sprite will also change whenever the instance&#39;s <span class="inline2"><a data-xref="{title}" href="../Asset_Management/Sprites/Sprite_Instance_Variables/sprite_index.htm">sprite_index</a></span> changes.</p>
+  <p>The sprite&#39;s frame will change based on the value of <span class="inline2"><a data-xref="{title}" href="../Asset_Management/Sprites/Sprite_Instance_Variables/image_index.htm">image_index</a></span>, and so is drawn animated in the sprite view. The sprite will also change whenever the instance&#39;s <span class="inline2"><a data-xref="{title}" href="../Asset_Management/Sprites/Sprite_Instance_Variables/sprite_index.htm">sprite_index</a></span> changes.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_text.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_text.htm
@@ -16,7 +16,7 @@
 <body>
   <h1><span data-field="title" data-format="default">dbg_text</span></h1>
   <p>This function creates a text entry within the current debug section.</p>
-  <p>Both a <span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span> and a <span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span> to a variable containing a string can be passed to the function. The text can be multiline.</p>
+  <p>Both a <span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span> and a <span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span> to a variable containing a string can be passed to the function. The text can be multiline.</p>
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> You cannot change the text through the control, it is read-only. See <span class="inline3_func"><a data-xref="{title}" href="dbg_text_input.htm">dbg_text_input</a></span> for a control that can change the text.</p>
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Single_Column.hts"> </div>
   <p> </p>
@@ -36,7 +36,7 @@
       </tr>
       <tr>
         <td>ref_or_string</td>
-        <td><span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span> or <span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span> or <span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td>A string or a reference to a variable that can be converted to string, returned by <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span></td>
       </tr>
     </tbody>
@@ -51,11 +51,9 @@
     ref_to_text = ref_create(self, &quot;text&quot;);<br />
     <span data-field="title" data-format="default">dbg_text</span>(ref_to_text);<br />
     <span data-field="title" data-format="default">dbg_text</span>(text);<br />
-    <span data-field="title" data-format="default">dbg_text</span>(&quot;More text&quot;);<br />
-    show_debug_overlay(true);
+    <span data-field="title" data-format="default">dbg_text</span>(&quot;More text&quot;);
   </p>
   <p>The above code assigns some text to an <a href="../../GML_Overview/Variables/Instance_Variables.htm">instance variable</a> <span class="inline2">text</span>. It then creates a reference to that variable using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span> and stores it in <span class="inline2">ref_to_text</span>. Next, it adds three text controls to a new debug view <span data-keyref="DebugView_Name_Default">&quot;Default&quot;</span> that will be created, under a new section <span data-keyref="DebugSection_Name_Default">&quot;Default&quot;</span>. The three calls to <span class="inline3_func"><span data-field="title" data-format="default">dbg_text</span></span> add a text entry in three different ways: the first provides the reference to the <span class="inline2">text</span> variable, the second passes the variable <span class="inline2">text</span> itself (which assigns the <em>value</em> the variable currently has) and the last passes a string directly.</p>
-  <p>Finally, <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> is shown using a call to <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span> with <span class="inline2">enabled</span> set to <span class="inline2">true</span>.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_text_input.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_text_input.htm
@@ -35,12 +35,12 @@
       </tr>
       <tr>
         <td>ref</td>
-        <td><span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
         <td>A reference to a variable created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span></td>
       </tr>
       <tr>
         <td>label</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The label to show next to the text input</td>
       </tr>
     </tbody>
@@ -53,11 +53,9 @@
   <p class="code_heading">Create Event</p>
   <p class="code">description = &quot;This description can be changed&quot;;<br />
     var _ref = ref_create(self, &quot;description&quot;);<br />
-    <span data-field="title" data-format="default">dbg_text_input</span>(_ref, &quot;Enter the description here:&quot;);<br />
-    show_debug_overlay(true);
+    <span data-field="title" data-format="default">dbg_text_input</span>(_ref, &quot;Enter the description here:&quot;);
   </p>
   <p>The above code first assigns some text to an instance variable <span class="inline2">description</span>. It then creates a reference to this variable using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span>. Next, it creates a text input control using <span class="inline3_func"><span data-field="title" data-format="default">dbg_text_input</span></span>, the reference <em>links</em> the control to the variable.</p>
-  <p>Finally, <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span> is called to show <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a>.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_view.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_view.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <h1><span data-field="title" data-format="default">dbg_view</span></h1>
-  <p>This function creates a custom debug view that can be accessed from <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a>.</p>
+  <p>This function creates a custom debug view and <span>sh<span>ows it in</span></span> <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a>.</p>
   <p>A debug view is a custom window in this overlay that contains sections that you can add controls to. The controls can change the value of the variable they reference.</p>
   <p>References to variables can be created using <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span>.</p>
   <h3>Usage Notes</h3>
@@ -41,44 +41,43 @@
       </tr>
       <tr>
         <td>name</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td>The name of the debug view</td>
       </tr>
       <tr>
         <td>visible</td>
-        <td><span data-keyref="Type_Bool"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
+        <td><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
         <td>Whether the debug view should be visible when the debug overlay is opened</td>
       </tr>
       <tr>
         <td>x</td>
-        <td><span data-keyref="Type_Real"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The x position of the debug view, the default -1 indicates it can be placed anywhere</td>
       </tr>
       <tr>
         <td>y</td>
-        <td><span data-keyref="Type_Real"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The y position of the debug view, the default -1 indicates it can be placed anywhere</td>
       </tr>
       <tr>
         <td>width</td>
-        <td><span data-keyref="Type_Real"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The width of the debug view (default is <span data-keyref="DebugView_Width_Default">500</span>)</td>
       </tr>
       <tr>
         <td>height</td>
-        <td><span data-keyref="Type_Real"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The height of the debug view (default is <span data-keyref="DebugView_Height_Default">400</span>)</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Pointer_DebugView"><a href="GameMaker_Language/GML_Reference/Debugging/dbg_view.htm" target="_blank">Pointer.DebugView</a></span></p>
+  <p class="code"><span data-keyref="Type_Pointer_DebugView"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/dbg_view.htm" target="_blank">Pointer.DebugView</a></span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_view</span>(&quot;CustomDebugView&quot;, true);<br />
-    show_debug_overlay(true);</p>
-  <p>The above code creates a new debug view named &quot;CustomDebugView&quot; and sets it to be visible when <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> is shown. It then shows the debug overlay.</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_view</span>(&quot;CustomDebugView&quot;, true);</p>
+  <p>The above code creates a new debug view named &quot;CustomDebugView&quot; and brings up <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> with the debug view visible.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_watch.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_watch.htm
@@ -16,7 +16,7 @@
 <body>
   <h1><span data-field="title" data-format="default">dbg_watch</span></h1>
   <p>This function creates a watch for any value within the current debug section.</p>
-  <p>Each value is converted to a <span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span> and displayed.</p>
+  <p>Each value is converted to a <span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span> and displayed.</p>
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Two_Columns.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
@@ -35,12 +35,12 @@
       </tr>
       <tr>
         <td>ref</td>
-        <td><span data-keyref="Type_DbgRef"><a href="GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></td>
         <td>A reference to a variable created with <span class="inline3_func"><a data-xref="{title}" href="../Variable_Functions/ref_create.htm">ref_create</a></span></td>
       </tr>
       <tr>
         <td>label</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The label to show</td>
       </tr>
     </tbody>
@@ -53,12 +53,11 @@
   <p class="code_heading">Create Event</p>
   <p class="code">counter = 0;<br />
     <br />
-    <span data-field="title" data-format="default">dbg_watch</span>(ref_create(self, &quot;counter&quot;), &quot;Counter&quot;);<br />
-    show_debug_overlay(true);
+    <span data-field="title" data-format="default">dbg_watch</span>(ref_create(self, &quot;counter&quot;), &quot;Counter&quot;);
   </p>
   <p class="code_heading">Step Event</p>
   <p class="code">counter += 1;</p>
-  <p>The above code first initialises a variable <span class="inline2">counter</span> in the Create event. It then adds a watch for this variable using <span class="inline3_func"><span data-field="title" data-format="default">dbg_watch</span></span> and brings up <a data-xref="{title}" href="The_Debug_Overlay.htm">The Debug Overlay</a> using <span class="inline3_func"><a data-xref="{title}" href="show_debug_overlay.htm">show_debug_overlay</a></span>.</p>
+  <p>The above code first initialises a variable <span class="inline2">counter</span> in the Create event. It then adds a watch for this variable using <span class="inline3_func"><span data-field="title" data-format="default">dbg_watch</span></span>.</p>
   <p>In the Step event, the counter is incremented, a change that will be shown by the watch.</p>
   <p> </p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/Variable_Functions.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/Variable_Functions.htm
@@ -15,7 +15,7 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">Variable Functions</span></h1>
-  <p>The functions on this page are designed to deal with all the different variables and variable types when using the GameMaker Language in your games. For more information on variables, please see the page on <a href="../../GML_Overview/Variables_And_Variable_Scope.htm">Variables and Variable Scope</a>.</p>
+  <p>The functions on this page are designed to deal with all the different variables and variable types when using the GameMaker Language in your games. For more information on variables, please see the page on <a data-xref="{title}" href="../../GML_Overview/Variables_And_Variable_Scope.htm">Variables And Variable Scope</a>.</p>
   <p>The following variable functions are available:</p>
   <ul class="colour">
     <li><a href="variable_instance_exists.htm">variable_instance_exists</a></li>
@@ -81,6 +81,11 @@
     <li><a href="bool.htm">bool</a></li>
     <li><a href="ptr.htm">ptr</a></li>
     <li><a href="int64.htm">int64</a></li>
+  </ul>
+  <h2>Reference Functions</h2>
+  <p>The f<span>oll<span>owing functi<span>ons relate t<span>o references: </span></span></span></span></p>
+  <ul class="colour">
+    <li><a data-xref="{title}" href="ref_create.htm">ref_create</a></li>
   </ul>
   <p> </p>
   <p>Also see: <a data-xref="{title}" href="Array_Functions.htm">Array Functions</a></p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/bool.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/bool.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>bool</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>bool</h1>
+  <h1><span data-field="title" data-format="default">bool</span></h1>
   <p>This function will attempt to convert a given value into a boolean data type, where the value will be returned as <span class="inline">true</span> if it is greater than 0.5, and <span class="inline">false</span> otherwise.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">bool(n);</p>
+  <p class="code"><span data-field="title" data-format="default">bool</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -51,7 +51,7 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="ptr.htm">ptr</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="ptr.htm">ptr</a></div>
       </div>
     </div>
     <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/instanceof.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/instanceof.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>instanceof</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>instanceof</h1>
+  <h1><span data-field="title" data-format="default">instanceof</span></h1>
   <p>This function can be used to get the name of the <a href="../../GML_Overview/Structs.htm">constructor function</a> that was used to create a struct. The struct itself should have been created using the <a href="../../GML_Overview/Language_Features/new.htm"><span class="inline"></span></a> <a href="../../GML_Overview/Language_Features/new.htm"><span class="inline">new</span></a> operator along with the constructor itself. You supply the variable with the struct reference to check and the function will return either a string with the constructor name or <span class="inline">undefined</span>.</p>
   <p class="note"><span data-conref="../../../assets/snippets/Tag_tip.hts"> </span> It&#39;s recommended to use <span class="inline3_func"><a data-xref="{title}" href="is_instanceof.htm">is_instanceof</a></span> to check the constructor of a struct, as it additionally allows you to check using parent constructors (i.e. constructors that the struct&#39;s constructor may have inherited from). <span class="inline3_func"><a data-xref="{title}" href="is_instanceof.htm">is_instanceof</a></span> also allows you to check using the constructor function reference directly instead of strings.</p>
   <h3>Usage Notes</h3>
@@ -27,7 +27,7 @@
   </ul>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">instanceof(struct_id);</p>
+  <p class="code"><span data-field="title" data-format="default">instanceof</span>(struct_id);</p>
   <table>
     <tbody>
       <tr>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/int64.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/int64.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>int64</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>int64</h1>
+  <h1><span data-field="title" data-format="default">int64</span></h1>
   <p>This function will attempt to convert a given value into a signed 64-bit integer, where the value <i>must</i> be either a real, a string, an <span class="inline">int64</span>, an <span class="inline">int32</span>, or a <span class="inline">ptr</span>. Anything else will cause the game to crash with an error message. You can check to see if a variable holds an int64 using the function <a href="is_int64.htm"><span class="inline">is_int64()</span></a>.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">int64(val);</p>
+  <p class="code"><span data-field="title" data-format="default">int64</span>(val);</p>
   <table>
     <tbody>
       <tr>
@@ -48,10 +48,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a data-xref="{title}" href="static_get.htm">static_get</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="ref_create.htm">ref_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 int64

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_array.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_array.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_array</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_array</h1>
+  <h1><span data-field="title" data-format="default">is_array</span></h1>
   <p>This function can be used to check and see if a variable holds an array (it will return <span class="inline">true</span>) or not (in which case it will return <span class="inline">false</span>).</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_array(n);</p>
+  <p class="code"><span data-field="title" data-format="default">is_array</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -29,14 +29,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Any">Variable</span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The variable to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">if is_array(a)<br />
@@ -51,10 +51,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_struct.htm">is_struct</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_struct.htm">is_struct</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_array

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_bool.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_bool.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_bool</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_bool</h1>
+  <h1><span data-field="title" data-format="default">is_bool</span></h1>
   <p>This function returns whether a given variable is a boolean (<span class="inline">true</span> ior <span class="inline">false</span>) or not. In some cases you want to check and see if a variable in <span data-keyref="GameMaker Name">GameMaker</span> holds a boolean value, and that&#39;s when you would use this function.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_bool(n);</p>
+  <p class="code"><span data-field="title" data-format="default">is_bool</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -29,14 +29,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Any">Variable</span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The argument to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4><b>Example:</b></h4>
   <p class="code">if is_bool(val)<br />
@@ -55,10 +55,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_array.htm">is_array</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_array.htm">is_array</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_bool

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_handle.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_handle.htm
@@ -30,14 +30,14 @@
       </tr>
       <tr>
         <td>val</td>
-        <td><span data-keyref="Type_Any"><a href="GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The value to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">if is_handle(a)<br />
@@ -52,7 +52,7 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="bool.htm">bool</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="bool.htm">bool</a></div>
       </div>
     </div>
     <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_infinity.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_infinity.htm
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_infinity</h1>
+  <h1><span data-field="title" data-format="default">is_infinity</span></h1>
   <p>This function returns whether a given variable is <span class="inline">infinity</span> (an infinite number) or not, returning <span class="inline">true</span> if it is, and <span class="inline">false</span> if it is not.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_infinity(n);</p>
+  <p class="code"><span data-field="title" data-format="default">is_infinity</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -29,14 +29,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Any"><a href="GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The argument to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4><b>Example:</b></h4>
   <p class="code">if is_infinity(global.value)<br />
@@ -51,7 +51,7 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_handle.htm">is_handle</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_handle.htm">is_handle</a></div>
       </div>
     </div>
     <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_instanceof.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_instanceof.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_instanceof</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" type="text/css" href="../../../assets/css/default.css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Gurpreet S. Matharoo" />
@@ -58,10 +58,10 @@
     <div class="buttons">
       <div class="clear">
         <div>Back: <a data-xref="{title}" href="Variable_Functions.htm">Variable Functions</a></div>
-        <div>Next: <a data-xref="{title}" href="typeof.htm">typeof</a></div>
+        <div>Next: <a data-xref="{title}" href="static_get.htm">static_get</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_instanceof

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_int32.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_int32.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_int32</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_int32</h1>
+  <h1><span data-field="title" data-format="default">is_int32</span></h1>
   <p>This function returns whether a given variable is a 32bit integer or not. In some cases you want to check and see what data type a variable holds in <span data-keyref="GameMaker Name">GameMaker</span> and that&#39;s when you would use this function. It returns <span class="inline">true</span> or <span class="inline">false</span> depending on whether the value is an int 32 or not.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_int32(n);</p>
+  <p class="code"><span data-field="title" data-format="default">is_int32</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -29,14 +29,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Any">Variable</span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The argument to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4><b>Example:</b></h4>
   <p class="code">if !is_int32(val)<br />
@@ -51,10 +51,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_int64.htm">is_int64</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_int64.htm">is_int64</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_int32

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_int64.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_int64.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_int64</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_int64</h1>
+  <h1><span data-field="title" data-format="default">is_int64</span></h1>
   <p>This function returns whether a given variable is a 64bit integer or not. In some cases you want to check and see what data type a variable holds in <span data-keyref="GameMaker Name">GameMaker</span> and that&#39;s when you would use this function. It returns <span class="inline">true</span> or <span class="inline">false</span> depending on whether the value is an int64 or not.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_int64(n);</p>
+  <p class="code"><span data-field="title" data-format="default">is_int64</span>(n);</p>
   <table>
     <tbody>
       <tr>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_nan.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_nan.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_nan</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_nan</h1>
+  <h1><span data-field="title" data-format="default">is_nan</span></h1>
   <p>This function returns whether a given variable is <span class="inline">NaN</span> (not a number) or not, returning <span class="inline">true</span> if it is, and <span class="inline">false</span> if it is not.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_nan(n);</p>
+  <p class="code"><span data-field="title" data-format="default">is_nan</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -29,14 +29,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Any">Variable</span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The argument to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4><b>Example:</b></h4>
   <p class="code">if is_nan(global.value)<br />
@@ -51,10 +51,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_infinity.htm">is_infinity</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_infinity.htm">is_infinity</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_nan

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_numeric.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_numeric.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_numeric</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_numeric</h1>
+  <h1><span data-field="title" data-format="default">is_numeric</span></h1>
   <p>This function returns whether a given variable is a numeric value (real, int32, int64 or boolean) or not. In some cases you want to check and see if a variable in <span data-keyref="GameMaker Name">GameMaker</span> holds any numeric value, and that&#39;s when you would use this function. The function will return <span class="inline">true</span> if the given input is numeric, and <span class="inline">false</span> otherwise.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_numeric(n);</p>
+  <p class="code"><span data-field="title" data-format="default">is_numeric</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -29,14 +29,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Any">Variable</span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The input to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4><b>Example:</b></h4>
   <p class="code">if is_numeric(val)<br />
@@ -51,10 +51,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_bool.htm">is_bool</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_bool.htm">is_bool</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_numeric

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_ptr.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_ptr.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_ptr</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_ptr</h1>
+  <h1><span data-field="title" data-format="default">is_ptr</span></h1>
   <p>This function returns whether a given variable is a pointer or not. In some cases you want to check and see what data type a variable holds in <span data-keyref="GameMaker Name">GameMaker</span> and that&#39;s when you would use this function. It returns <span class="inline">true</span> or <span class="inline">false</span> depending on whether the value is a pointer or not.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_ptr(n);</p>
+  <p class="code"><span data-field="title" data-format="default">is_ptr</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -29,14 +29,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Any">Variable</span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The argument to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4><b>Example:</b></h4>
   <p class="code">if !is_ptr(val)<br />
@@ -51,10 +51,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_int32.htm">is_int32</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_int32.htm">is_int32</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_ptr

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_real.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_real.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_real</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,12 +15,12 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_real</h1>
+  <h1><span data-field="title" data-format="default">is_real</span></h1>
   <p>This function returns whether a given variable is a real number (single, double or integer) or not. In some cases you want to check and see if a variable holds a real number, and that&#39;s when you would use this function. It does <i>not</i> return the real number but rather <span class="inline">true</span> or <span class="inline">false</span>, so a value of, for example, &quot;fish&quot; would return <span class="inline">false</span>, however a value of 200 would return <span class="inline">true</span>.</p>
-  <p class="note"><strong>NOTE</strong>: This function will return <span class="inline">false</span> for any <a href="../../GML_Overview/Variables/Constants.htm#enumhead">enum</a> values as they are stored as int64s. The correct function to check for that data type is <span class="inline"><a href="is_int64.htm">is_int64()</a></span>.</p>
+  <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> This function will return <span class="inline">false</span> for any <a href="../../GML_Overview/Variables/Constants.htm#enumhead">enum</a> values as they are stored as int64s. The correct function to check for that data type is <span class="inline"><a href="is_int64.htm">is_int64()</a></span>.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_real(n);</p>
+  <p class="code"><span data-field="title" data-format="default">is_real</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -30,14 +30,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Any">Variable</span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The argument to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4><b>Example:</b></h4>
   <p class="code">if is_real(val)<br />
@@ -52,10 +52,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_numeric.htm">is_numeric</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_numeric.htm">is_numeric</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_real

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_string.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_string.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_string</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_string</h1>
+  <h1><span data-field="title" data-format="default">is_string</span></h1>
   <p>This function returns whether a given variable is a string number or not. In some cases you want to check and see if a variable in <span data-keyref="GameMaker Name">GameMaker</span> holds a string and not a real and that&#39;s when you would use this function. It does <i>not</i> return the string but rather <span class="inline">true</span> or <span class="inline">false</span>, so a value of, for example, &quot;fish&quot; for n will return <span class="inline">true</span>, but a value of 200 for n will return <span class="inline">false</span>.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_string(n);</p>
+  <p class="code"><span data-field="title" data-format="default">is_string</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -29,14 +29,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Any">Variable</span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The argument to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4><b>Example:</b></h4>
   <p class="code">if is_string(val)<br />
@@ -51,10 +51,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_real.htm">is_real</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_real.htm">is_real</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_string

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_struct.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_struct.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>is_struct</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,12 +15,12 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>is_struct</h1>
+  <h1><span data-field="title" data-format="default">is_struct</span></h1>
   <p>This function checks if the supplied value is a struct. It returns <span class="inline">true</span> if it is, otherwise it returns <span class="inline">false</span>.</p>
   <p>Note that <a href="../../GML_Overview/Method_Variables.htm">method variables</a> will also return <span class="inline">true</span>, and <a href="../Asset_Management/Instances/Instances.htm">object instances</a> will return <span class="inline">false</span>.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">is_struct(val);</p>
+  <p class="code"><span data-field="title" data-format="default">is_struct</span>(val);</p>
   <table>
     <tbody>
       <tr>
@@ -30,14 +30,14 @@
       </tr>
       <tr>
         <td>val</td>
-        <td><span data-keyref="Type_Any">Variable</span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The value to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">if is_struct(a)<br />
@@ -52,10 +52,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_method.htm">is_method</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_method.htm">is_method</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_struct

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_undefined.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/is_undefined.htm
@@ -15,9 +15,9 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1 id="h">is_undefined</h1>
+  <h1 id="h"><span data-field="title" data-format="default">is_undefined</span></h1>
   <p>This function returns whether a given variable is defined or not. In some cases you want to check and see what data type a variable holds in <span data-keyref="GameMaker Name">GameMaker</span> and that&#39;s when you would use this function. It returns <span class="inline">true</span> or <span class="inline">false</span> depending on whether the value is defined or not.<b></b></p>
-  <p class="note"><b>NOTE</b>: This function <b>cannot</b> be used to verify the existence of a variable. Use <span style="font-size:1px;"><a href="variable_instance_exists.htm"><span class="inline">variable_instance_exists()</span></a></span> or <span style="font-size:1px;"><a href="variable_global_exists.htm"><span class="inline">variable_global_exists()</span></a></span> instead.</p>
+  <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> This function <b>cannot</b> be used to verify the existence of a variable. Use <span style="font-size:1px;"><a href="variable_instance_exists.htm"><span class="inline">variable_instance_exists()</span></a></span> or <span style="font-size:1px;"><a href="variable_global_exists.htm"><span class="inline">variable_global_exists()</span></a></span> instead.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code">is_undefined(n);</p>
@@ -30,14 +30,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Any">Variable</span></td>
+        <td><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span></td>
         <td>The argument to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
+  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
   <p> </p>
   <h4><b>Example:</b></h4>
   <p class="code">var val = ds_map_find_value(map, 13);<br />
@@ -53,10 +53,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="is_nan.htm">is_nan</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_nan.htm">is_nan</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 is_undefined

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/method_call.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/method_call.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>method_call</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" type="text/css" href="../../../assets/css/default.css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="" />
@@ -78,10 +78,10 @@
     <div class="buttons">
       <div class="clear">
         <div>Back: <a data-xref="{title}" href="Variable_Functions.htm">Variable Functions</a></div>
-        <div>Next: <a data-xref="{title}" href="is_string.htm">is_string</a></div>
+        <div>Next: <a data-xref="{title}" href="variable_struct_exists.htm">struct_exists</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 method_call

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/ptr.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/ptr.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>ptr</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,11 +15,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>ptr</h1>
+  <h1><span data-field="title" data-format="default">ptr</span></h1>
   <p>This function will attempt to convert a given value into a pointer data type, where the value <i>must</i> be either a <span class="inline">real</span>, a <span class="inline">string</span>, an <span class="inline">int64</span>, an <span class="inline">int32</span>, or a <span class="inline">ptr</span>. Anything else will cause the game to crash with an error message.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code">ptr(n);</p>
+  <p class="code"><span data-field="title" data-format="default">ptr</span>(n);</p>
   <table>
     <tbody>
       <tr>
@@ -29,14 +29,14 @@
       </tr>
       <tr>
         <td>n</td>
-        <td><span data-keyref="Type_Real">Real</span>, <span data-keyref="Type_String">String</span>, or <span data-keyref="Type_Pointer">Pointer</span></td>
+        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span>, <span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span>, or <span data-keyref="Type_Pointer"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Pointer</a></span></td>
         <td>The value to convert.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Pointer">Pointer</span></p>
+  <p class="code"><span data-keyref="Type_Pointer"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Pointer</a></span></p>
   <p> </p>
   <h4><b>Example:</b></h4>
   <p class="code">if !is_ptr(val)<br />
@@ -51,10 +51,10 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="int64.htm">int64</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="int64.htm">int64</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 ptr

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/ref_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/ref_create.htm
@@ -51,12 +51,12 @@
       </tr>
       <tr>
         <td>dbgrefOrStruct</td>
-        <td><span data-keyref="Type_DbgRef">Variable &quot;Type_DbgRef&quot; is not defined</span> or <span data-keyref="Type_Struct"><a href="../../../../GameMaker_Language/GML_Overview/Structs.htm" target="_blank">Struct</a></span></td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span> or <span data-keyref="Type_Struct"><a href="../../../../GameMaker_Language/GML_Overview/Structs.htm" target="_blank">Struct</a></span></td>
         <td>The <a data-xref="{bookmarkText}" href="../../GML_Overview/Structs.htm#struct">struct</a> or <a href="../Asset_Management/Instances/Instances.htm">instance</a> containing the variable to reference, or a reference to it</td>
       </tr>
       <tr>
         <td>dbgrefOrIndex</td>
-        <td><span data-keyref="Type_DbgRef">Variable &quot;Type_DbgRef&quot; is not defined</span> or <span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span> or <span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td>The name of the variable or reference to it</td>
       </tr>
       <tr>
@@ -68,7 +68,7 @@
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_DbgRef">Variable &quot;Type_DbgRef&quot; is not defined</span></p>
+  <p class="code"><span data-keyref="Type_DbgRef"><a href="../../../../GameMaker_Language/GML_Reference/Debugging/ref_create.htm" target="_blank">Reference</a></span></p>
   <p> </p>
   <h4>Example 1: Basic Reference to an Instance Variable</h4>
   <p class="code">text = &quot;This is some text&quot;;<br />
@@ -98,7 +98,7 @@
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div>Back: <a data-xref="{title}" href="../Debugging/Debugging.htm">Debugging</a></div>
+        <div>Back: <a data-xref="{title}" href="Variable_Functions.htm">Variable Functions</a></div>
         <div>Next: </div>
       </div>
     </div>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/static_set.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/static_set.htm
@@ -35,12 +35,12 @@
       </tr>
       <tr>
         <td>struct</td>
-        <td><span data-keyref="Type_Struct"><a href="GameMaker_Language/GML_Overview/Structs.htm" target="_blank">Struct</a></span></td>
+        <td><span data-keyref="Type_Struct"><a href="../../../../GameMaker_Language/GML_Overview/Structs.htm" target="_blank">Struct</a></span></td>
         <td>The struct to set the static struct for</td>
       </tr>
       <tr>
         <td>static_struct</td>
-        <td><span data-keyref="Type_Struct"><a href="GameMaker_Language/GML_Overview/Structs.htm" target="_blank">Struct</a></span></td>
+        <td><span data-keyref="Type_Struct"><a href="../../../../GameMaker_Language/GML_Overview/Structs.htm" target="_blank">Struct</a></span></td>
         <td>The new static struct to use for the struct</td>
       </tr>
     </tbody>
@@ -85,7 +85,7 @@
     <div class="buttons">
       <div class="clear">
         <div>Back: <a data-xref="{title}" href="Variable_Functions.htm">Variable Functions</a></div>
-        <div>Next: <a data-xref="{title}" href="variable_instance_exists.htm">variable_instance_exists</a></div>
+        <div>Next: <a data-xref="{title}" href="instanceof.htm">instanceof</a></div>
       </div>
     </div>
     <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/variable_struct_exists.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/variable_struct_exists.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>struct_exists</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -55,7 +55,7 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="variable_struct_get.htm">variable_struct_get</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="variable_struct_get.htm">struct_get</a></div>
       </div>
     </div>
     <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/variable_struct_get.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/variable_struct_get.htm
@@ -31,19 +31,19 @@
       </tr>
       <tr>
         <td>struct</td>
-        <td><span data-keyref="Type_Struct"><a href="GameMaker_Language/GML_Overview/Structs.htm" target="_blank">Struct</a></span></td>
+        <td><span data-keyref="Type_Struct"><a href="../../../../GameMaker_Language/GML_Overview/Structs.htm" target="_blank">Struct</a></span></td>
         <td>The struct reference to use</td>
       </tr>
       <tr>
         <td>name</td>
-        <td><span data-keyref="Type_String"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
+        <td><span data-keyref="Type_String"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td>The name of the variable to get (as a string)</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Any"><a href="GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span> (any data type) or <span data-keyref="Type_Undefined"><a href="GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">undefined</a></span> (if the named variable does not exist)<span class="inline"></span></p>
+  <p class="code"><span data-keyref="Type_Any"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm#variable" target="_blank">Any</a></span> (any data type) or <span data-keyref="Type_Undefined"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">undefined</a></span> (if the named variable does not exist)<span class="inline"></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">if struct_exists(mystruct, &quot;shields&quot;)<br />
@@ -61,7 +61,7 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="variable_struct_set.htm">variable_struct_set</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="variable_struct_set.htm">struct_set</a></div>
       </div>
     </div>
     <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/variable_struct_get_names.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/variable_struct_get_names.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>struct_get_names</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -88,7 +88,7 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="variable_struct_names_count.htm">variable_struct_names_count</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="variable_struct_names_count.htm">struct_names_count</a></div>
       </div>
     </div>
     <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/variable_struct_names_count.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/variable_struct_names_count.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>struct_names_count</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -49,7 +49,7 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="instanceof.htm">instanceof</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="is_instanceof.htm">is_instanceof</a></div>
       </div>
     </div>
     <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/variable_struct_set.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/variable_struct_set.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>struct_set</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -14,11 +14,11 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">variable_struct_set</span></h1>
+  <h1><span data-field="title" data-format="default">struct_set</span></h1>
   <p>With this function you can set the value of a given variable in a struct. You supply the struct reference as well as the name of the variable to set the value of <i>as a string</i> (see example code below), and then finally the value to set (can be any valid <a href="../../GML_Overview/Data_Types.htm">data type</a>). If the variable does not exist already in the struct it will be created and then assigned the value.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">variable_struct_set</span>(struct, name, val);</p>
+  <p class="code"><span data-field="title" data-format="default">struct_set</span>(struct, name, val);</p>
   <table>
     <tbody>
       <tr>
@@ -50,7 +50,7 @@
   <h4>Example:</h4>
   <p class="code">if !struct_exists(mystruct, &quot;shields&quot;)<br />
     {<br />
-        <span data-field="title" data-format="default">variable_struct_set</span>(mystruct, &quot;shields&quot;, 0);<br />
+        <span data-field="title" data-format="default">struct_set</span>(mystruct, &quot;shields&quot;, 0);<br />
     }</p>
   <p>The above code will check to see if the given variable exists in the given struct and if it does not then it is created and set to 0.</p>
   <p> </p>
@@ -59,7 +59,7 @@
     <div class="buttons">
       <div class="clear">
         <div style="float:left">Back: <a href="Variable_Functions.htm">Variable Functions</a></div>
-        <div style="float:right">Next: <a href="variable_struct_remove.htm"><span>variable_struct_remove</span></a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="variable_struct_remove.htm">struct_remove</a></div>
       </div>
     </div>
     <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>

--- a/Manual/toc/Default.toc
+++ b/Manual/toc/Default.toc
@@ -738,6 +738,7 @@
         <page href="../contents/GameMaker_Language/GML_Reference/Variable_Functions/bool.htm" format="html" processing-role="normal"></page>
         <page href="../contents/GameMaker_Language/GML_Reference/Variable_Functions/ptr.htm" format="html" processing-role="normal"></page>
         <page href="../contents/GameMaker_Language/GML_Reference/Variable_Functions/int64.htm" format="html" processing-role="normal"></page>
+        <page href="../contents/GameMaker_Language/GML_Reference/Variable_Functions/ref_create.htm" format="html" processing-role="normal"></page>
       </book>
       <book href="../contents/GameMaker_Language/GML_Reference/Variable_Functions/Array_Functions.htm" format="html" processing-role="normal">
         <page href="../contents/GameMaker_Language/GML_Reference/Variable_Functions/array_create.htm" format="html" processing-role="normal"></page>


### PR DESCRIPTION
* Removed paragraphs on debug overlay pages saying that `show_debug_overlay` needs to be called after calls to `dbg_*` functions. Worded things a bit differently here and there as well.
* Updated Back/Next links & minor improvements to pages (replacing names with Title field, etc.)