### PR TITLE
Improvements to static documentation

### DIFF
--- a/Manual/contents/GameMaker_Language/GML_Overview/Addressing_Variables_In_Other_Instances.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Addressing_Variables_In_Other_Instances.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>Addressing Variables In Other Instances</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../assets/css/default.css" type="text/css" />
   <script src="../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -75,7 +75,6 @@
   </p>
   <p> </p>
   <p> </p>
-  <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
@@ -83,7 +82,7 @@
         <div style="float:right">Next: <a data-xref="{title}" href="Expressions_And_Operators.htm">Expressions And Operators</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 variables - addressing

--- a/Manual/contents/GameMaker_Language/GML_Overview/Functions/Static_Variables.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Functions/Static_Variables.htm
@@ -58,6 +58,24 @@
   </p>
   <p>In the example above, the <span class="inline2">weapon</span> constructor holds a static variable called <span class="inline2">number_of_weapons</span>, which is shared across all of its structs. With each new call to the <span class="inline2">weapon</span> constructor, the <span class="inline2">number_of_weapons</span> value goes up by 1.</p>
   <p>After being called twice, the value of that variable becomes <span class="inline2">2</span>, which can be read from any of its structs, or from the constructor directly by writing <span class="inline2">weapon.number_of_weapons</span>.</p>
+  <h3>Statics in Parent-Child Constructors</h3>
+  <p>Generally, static variables are always scoped to the function you define them in. In a hierarchy of constructors a static variable is scoped to the constructor you define it in using the <span class="inline2">static</span> keyword: </p>
+  <p class="code">function item() constructor<br />
+    {<br />
+        static number = 0;<br />
+    }<br />
+    function weapon() : item() constructor<br />
+    {<br />
+        static types = [&quot;sword&quot;, &quot;bow&quot;, &quot;hammer&quot;];<br />
+    }<br />
+    <br />
+    my_weapon = new weapon();
+  </p>
+  <p>Here the static variable <span class="inline2">number</span> belongs to <span class="inline2">item</span> and the static variable <span class="inline2">types</span> belongs to <span class="inline2">weapon</span>.</p>
+  <p>You can access both static variables through structs created from <span class="inline2">weapon</span>: </p>
+  <p class="code">show_debug_message(my_weapon.number); // 0<br />
+    show_debug_message(my_weapon.types);  // [&quot;sword&quot;, &quot;bow&quot;, &quot;hammer&quot;]</p>
+  <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> In more complex constructor hierarchies you might need to traverse the <a data-xref="{text}" href="../Structs/Static_Structs.htm#h">Static Chain</a>.</p>
   <h2>Accessing Static Variables</h2>
   <p>You can read a static value for a function using the <span class="inline2">&lt;function_name&gt;.&lt;static_variable&gt;</span> syntax.</p>
   <p>Say, for a function called <span class="inline2">counter</span>, you have a static variable <span class="inline2">count</span>. You can access that by typing <span class="inline2">counter.count</span> after its first call.</p>
@@ -73,7 +91,7 @@
     <br />
     show_debug_message(counter.count);
   </p>
-  <p>You can&#39;t access a static variable from a function that was never called, as static variables are initialised on the first call to a function. Trying to do so will give you an error and crash your game.</p>
+  <div data-conref="../../../assets/snippets/Note_Warning_Static_Struct_Call_Once.hts"> </div>
   <p>For constructors, you can access static variables from the constructor function directly, or from any of the structs created from the constructor:</p>
   <p class="code">function weapon() constructor<br />
     {<br />

--- a/Manual/contents/GameMaker_Language/GML_Overview/Functions/Static_Variables.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Functions/Static_Variables.htm
@@ -59,7 +59,7 @@
   <p>In the example above, the <span class="inline2">weapon</span> constructor holds a static variable called <span class="inline2">number_of_weapons</span>, which is shared across all of its structs. With each new call to the <span class="inline2">weapon</span> constructor, the <span class="inline2">number_of_weapons</span> value goes up by 1.</p>
   <p>After being called twice, the value of that variable becomes <span class="inline2">2</span>, which can be read from any of its structs, or from the constructor directly by writing <span class="inline2">weapon.number_of_weapons</span>.</p>
   <h3>Statics in Parent-Child Constructors</h3>
-  <p>Generally, static variables are always scoped to the function you define them in. In a hierarchy of constructors a static variable is scoped to the constructor you define it in using the <span class="inline2">static</span> keyword: </p>
+  <p>Generally, static variables are scoped to the function you define them in. In a hierarchy of constructors, a static variable is scoped to the constructor you define it in using the <span class="inline2">static</span> keyword: </p>
   <p class="code">function item() constructor<br />
     {<br />
         static number = 0;<br />

--- a/Manual/contents/GameMaker_Language/GML_Overview/Structs.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Structs.htm
@@ -269,10 +269,7 @@
     <li>Structs can have static variables, objects cannot. <a data-xref="{title}" href="../../The_Asset_Editors/Object_Properties/Object_Variables.htm">Object Variables</a> are not the equivalent of static variables; they don&#39;t belong to the object, rather they provide default values for <a data-xref="{title}" href="Variables/Instance_Variables.htm">Instance Variables</a> that are assigned to instances created from that object before the Create event runs.</li>
   </ul>
   <h2>Struct Functions</h2>
-  <p>Finally, there are a number of runtime functions that you can use on structs to get the variables they contain as well as a few other things. You can find them in the following section:</p>
-  <ul class="colour">
-    <li><a data-xref="{text}" href="../GML_Reference/Variable_Functions/Variable_Functions.htm#h">Struct Functions</a></li>
-  </ul>
+  <p>Finally, there are a number of runtime functions that you can use on structs to get the variables they contain as well as a few other things. You can find them under <a data-xref="{text}" href="../GML_Reference/Variable_Functions/Variable_Functions.htm#struct_functions">Struct Functions</a>.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Overview/Structs/Static_Structs.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Structs/Static_Structs.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>Static Struct</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Gurpreet S. Matharoo" />
@@ -21,7 +21,7 @@
         return count ++;<br />
     }<br />
     <br />
-    repeat (10) counter()<br />
+    repeat (10) counter();<br />
     <br />
     // Get static struct of counter()<br />
     var _static_counter = static_get(counter);<br />
@@ -32,6 +32,7 @@
   </p>
   <p>This is also true for <a href="../Structs.htm#constr">constructor functions</a>. Each constructor has a static struct, where its static variables and static methods are stored.</p>
   <p>Every struct created from the constructor accesses its static variables from that static struct.</p>
+  <div data-conref="../../../assets/snippets/Note_Warning_Static_Struct_Call_Once.hts"> </div>
   <h2 id="h">Static Chain</h2>
   <p>When you use constructor inheritance, those constructors form a &quot;static chain&quot; - a chain of static structs where each child links to its parent.</p>
   <p>For example, let&#39;s say you have a constructor <span class="inline2">item</span>, and a constructor <span class="inline2">potion</span> which is a child of <span class="inline2">item</span>:</p>
@@ -52,6 +53,108 @@
     show_debug_message(static_get(item) == static_get(_static_potion)); // true (1)
   </p>
   <p>This is because <span class="inline2">item</span> is the parent of the <span class="inline2">potion</span> constructor, so the static struct for <span class="inline2">item</span> is linked to the static struct for <span class="inline2">potion</span>.</p>
+  <p>The static structs of the top-level constructor functions, i.e. those that don&#39;t have a parent constructor, share the same parent struct. This struct is the &quot;root&quot; struct, which has <span class="inline2">undefined</span> as its parent struct: </p>
+  <p class="code">var _static_item = static_get(item);         // the static struct of item<br />
+    var _root = static_get(_static_item);        // the static struct of all top-level static structs<br />
+    var _must_be_undefined = static_get(_root);  // undefined</p>
+  <p>This shared struct is the root parent struct of <em>all</em> structs and defines the default <span class="inline3_func">toString</span> function that&#39;s called when the struct is converted to string.</p>
+  <p>This means that you can get the full static chain of a struct as follows:</p>
+  <p class="code">static_chain = [];<br />
+    var _node = static_get(potion);                        // the static struct to start at<br />
+    while (!is_undefined(_node))<br />
+    {<br />
+        array_push(static_chain, _node);<br />
+        _node = static_get(_node);<br />
+    };<br />
+    <br />
+    array_foreach(static_chain, show_debug_message);       // output the path to the root struct
+  </p>
+  <h2>Same Variable Name in Parent &amp; Child Constructor</h2>
+  <p>As static variables belong to the constructor in which they&#39;re defined, it is possible to define a static variable in a child constructor with the same name as a static variable of the parent constructor. For example: </p>
+  <p class="code">function shape () constructor<br />
+    {<br />
+        static count = 0;<br />
+        count++;<br />
+        <br />
+        static shapes = [];<br />
+        array_push(shapes, self);<br />
+    }<br />
+    function rectangle () : shape () constructor<br />
+    {<br />
+        static count = 0;<br />
+        count++;<br />
+    }<br />
+    function square () : rectangle () constructor<br />
+    {<br />
+        static count = 0;<br />
+        count++;<br />
+    }<br />
+    function ellipse () : shape () constructor<br />
+    {<br />
+        static count = 0;<br />
+        count++;<br />
+    }</p>
+  <p>Each shape now has its own <span class="inline2">count</span> variable that keeps track of the number of items of that shape. Child shapes will increment the counter of their parent shape as well: </p>
+  <p class="code">s1 = new shape();        // Added 1 shape<br />
+    s2 = new rectangle();    // Added 1 rectangle (and therefore also 1 shape)<br />
+    s3 = new square();       // Added 1 square (and therefore also 1 rectangle and 1 shape)<br />
+    s4 = new ellipse();      // Added 1 ellipse (and therefore also 1 shape)<br />
+    <br />
+    show_debug_message($&quot;Number of shapes: {shape.count}&quot;);          // 4<br />
+    show_debug_message($&quot;Number of rectangles: {rectangle.count}&quot;);  // 2<br />
+    show_debug_message($&quot;Number of squares: {square.count}&quot;);        // 1<br />
+    show_debug_message($&quot;Number of ellipses: {ellipse.count}&quot;);      // 1
+  </p>
+  <h2>How the Dot Operator Looks Up a Variable Name</h2>
+  <p>If the struct itself contains a (non-static) variable with this name, the dot operator returns this variable. If it doesn&#39;t, the dot operator returns the first variable in the static chain with that name, checking the static struct and the entire static chain, if needed, until a variable with that name is encountered. If the variable name cannot be found anywhere in the static chain, <span data-keyref="GameMaker Name">GameMaker</span> will throw an error.</p>
+  <p>For example: </p>
+  <p class="code">function root() constructor {<br />
+        static show = function() {<br />
+            show_debug_message(&quot;root&quot;);<br />
+        }<br />
+    }<br />
+    function child() : root() constructor { }<br />
+    function child_with_static_func() : root() constructor {<br />
+        static show = function() {<br />
+            show_debug_message(&quot;child_with_static_func&quot;);<br />
+        }<br />
+    }<br />
+    function child_with_func() : root() constructor {<br />
+        show = function() {<br />
+            show_debug_message(&quot;child_with_func&quot;);<br />
+        }<br />
+    }<br />
+    <br />
+    child1 = new child();<br />
+    child1.show();<br />
+    child2 = new child_with_static_func();<br />
+    child2.show();<br />
+    child3 = new child_with_func();<br />
+    child3.show();
+  </p>
+  <p>The following happens in the above code: </p>
+  <ul class="colour">
+    <li><span class="inline2">child1</span> is a <span class="inline2">child</span>, which has no <span class="inline3_func">show()</span> method of its own but inherits from <span class="inline2">root</span>. <span class="inline3_func">root.show()</span> is called and <span class="inline2">&quot;root&quot;</span> is output.</li>
+    <li><span class="inline2">child2</span> is a <span class="inline2">child_with_static_func</span>, which has a static <span class="inline2">show()</span> method. This method is called, which outputs <span class="inline2">&quot;child_with_static_func&quot;</span>.</li>
+    <li><span class="inline2">child3</span> is a <span class="inline2">child_with_func</span>, which inherits from <span class="inline2">root</span> but also has its own (non-static) <span class="inline3_func">show()</span> method. It calls its own <span class="inline3_func">show()</span> method, outputting <span class="inline2">&quot;child_with_func&quot;</span>.</li>
+  </ul>
+  <h2>Parent&#39;s Static Variable or Method</h2>
+  <p>In certain situations you may want to access a static variable or method of the parent constructor from within the child constructor. To achieve this, you can go up the static chain and access the parent&#39;s static variable: </p>
+  <p class="code">function parent() constructor<br />
+    {<br />
+        static init = function() { show_debug_message(&quot;Parent Init&quot;); }<br />
+    }<br />
+    function child() : parent() constructor<br />
+    {<br />
+        static init = function()<br />
+        {<br />
+            var _static = static_get(self);<br />
+            var _static_parent = static_get(_static);<br />
+            _static_parent.init();<br />
+            <br />
+            show_debug_message(&quot;Child Init&quot;);<br />
+        }<br />
+    }</p>
   <h2>Checking Inheritance</h2>
   <p>You can use <span class="inline3_func"><a data-xref="{title}" href="../../GML_Reference/Variable_Functions/is_instanceof.htm">is_instanceof</a></span> to check if a struct belongs to the given constructor, or has the constructor as a parent.</p>
   <p>This is done by checking if your struct has the given constructor&#39;s static struct anywhere in its static chain.</p>

--- a/Manual/contents/GameMaker_Language/GML_Overview/Structs/Static_Structs.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Structs/Static_Structs.htm
@@ -53,7 +53,7 @@
     show_debug_message(static_get(item) == static_get(_static_potion)); // true (1)
   </p>
   <p>This is because <span class="inline2">item</span> is the parent of the <span class="inline2">potion</span> constructor, so the static struct for <span class="inline2">item</span> is linked to the static struct for <span class="inline2">potion</span>.</p>
-  <p>The static structs of the top-level constructor functions, i.e. those that don&#39;t have a parent constructor, share the same parent struct. This struct is the &quot;root&quot; struct, which has <span class="inline2">undefined</span> as its parent struct: </p>
+  <p>The static structs of the top-level constructor functions, i.e. those that don&#39;t have a parent constructor, share the same parent struct. This struct is the &quot;root&quot; static struct, which has <span class="inline2">undefined</span> as its parent struct: </p>
   <p class="code">var _static_item = static_get(item);         // the static struct of item<br />
     var _root = static_get(_static_item);        // the static struct of all top-level static structs<br />
     var _must_be_undefined = static_get(_root);  // undefined</p>
@@ -94,7 +94,7 @@
         static count = 0;<br />
         count++;<br />
     }</p>
-  <p>Each shape now has its own <span class="inline2">count</span> variable that keeps track of the number of items of that shape. Child shapes will increment the counter of their parent shape as well: </p>
+  <p>Each shape now has its own <span class="inline2">count</span> static variable that keeps track of the number of items of that shape. Child shapes will increment the <span class="inline2">count</span> of their parent shapes as well, as they run their parents&#39; constructors in addition to their own.</p>
   <p class="code">s1 = new shape();        // Added 1 shape<br />
     s2 = new rectangle();    // Added 1 rectangle (and therefore also 1 shape)<br />
     s3 = new square();       // Added 1 square (and therefore also 1 rectangle and 1 shape)<br />
@@ -105,20 +105,24 @@
     show_debug_message($&quot;Number of squares: {square.count}&quot;);        // 1<br />
     show_debug_message($&quot;Number of ellipses: {ellipse.count}&quot;);      // 1
   </p>
-  <h2>How the Dot Operator Looks Up a Variable Name</h2>
-  <p>If the struct itself contains a (non-static) variable with this name, the dot operator returns this variable. If it doesn&#39;t, the dot operator returns the first variable in the static chain with that name, checking the static struct and the entire static chain, if needed, until a variable with that name is encountered. If the variable name cannot be found anywhere in the static chain, <span data-keyref="GameMaker Name">GameMaker</span> will throw an error.</p>
-  <p>For example: </p>
+  <h2 id="h2">How the Dot Operator Looks Up a Variable Name</h2>
+  <p>Let&#39;s say you&#39;re looking for a specific variable in a struct, using the dot operator (i.e. <span class="inline2">struct.variable_name</span>).</p>
+  <p>If the struct contains a non-static variable with that name, the dot operator returns that variable. If it doesn&#39;t, the dot operator returns the first variable in the static chain with that name, checking the current static struct, and then traversing back the entire static chain, if needed, until a variable with that name is encountered. If the variable name cannot be found anywhere in the static chain, <span data-keyref="GameMaker Name">GameMaker</span> will throw an error.</p>
+  <p>For example:</p>
   <p class="code">function root() constructor {<br />
         static show = function() {<br />
             show_debug_message(&quot;root&quot;);<br />
         }<br />
     }<br />
+    <br />
     function child() : root() constructor { }<br />
+    <br />
     function child_with_static_func() : root() constructor {<br />
         static show = function() {<br />
             show_debug_message(&quot;child_with_static_func&quot;);<br />
         }<br />
     }<br />
+    <br />
     function child_with_func() : root() constructor {<br />
         show = function() {<br />
             show_debug_message(&quot;child_with_func&quot;);<br />
@@ -127,8 +131,10 @@
     <br />
     child1 = new child();<br />
     child1.show();<br />
+    <br />
     child2 = new child_with_static_func();<br />
     child2.show();<br />
+    <br />
     child3 = new child_with_func();<br />
     child3.show();
   </p>
@@ -142,19 +148,21 @@
   <p>In certain situations you may want to access a static variable or method of the parent constructor from within the child constructor. To achieve this, you can go up the static chain and access the parent&#39;s static variable: </p>
   <p class="code">function parent() constructor<br />
     {<br />
-        static init = function() { show_debug_message(&quot;Parent Init&quot;); }<br />
+        static init = function() { show_debug_message(&quot;Parent Innit?&quot;); }<br />
     }<br />
+    <br />
     function child() : parent() constructor<br />
     {<br />
         static init = function()<br />
         {<br />
             var _static = static_get(self);<br />
             var _static_parent = static_get(_static);<br />
-            _static_parent.init();<br />
+            _static_parent.init(); // Calls the parent&#39;s init()<br />
             <br />
-            show_debug_message(&quot;Child Init&quot;);<br />
+            show_debug_message(&quot;Child Innit!&quot;);<br />
         }<br />
-    }</p>
+    }
+  </p>
   <h2>Checking Inheritance</h2>
   <p>You can use <span class="inline3_func"><a data-xref="{title}" href="../../GML_Reference/Variable_Functions/is_instanceof.htm">is_instanceof</a></span> to check if a struct belongs to the given constructor, or has the constructor as a parent.</p>
   <p>This is done by checking if your struct has the given constructor&#39;s static struct anywhere in its static chain.</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Instances/Instance_Variables/Instance_Variables.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Instances/Instance_Variables/Instance_Variables.htm
@@ -33,7 +33,7 @@
   <p>Instances also have one general variable, or rather <a href="../../../../GML_Overview/Method_Variables.htm">method</a>, that can be defined to change how this instance is converted to <a href="../../../Strings/Strings.htm">string</a>: <br />
      </p>
   <ul class="Disc">
-    <li> </li>
+    <li><a data-xref="{text}" href="../../../Strings/Strings.htm#h3">toString() Method</a></li>
   </ul>
   <h2><label for="four">Movement And Position</label></h2>
   <p>These variables deal with the instance position and movement:</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Instances/instance_id.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Instances/instance_id.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>instance_id</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../../assets/css/default.css" type="text/css" />
   <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,13 +15,13 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1>instance_id</h1>
-  <p>This <b>read only</b> <a href="../../../GML_Overview/Arrays.htm">array</a> holds all the <a href="Instance_Variables/id.htm"><span class="inline">id</span>s</a> of every <em>active </em>instance within the room. This means that if you have used any of the <a href="Deactivating_Instances/Deactivating_Instances.htm">Instance Deactivate</a> functions those instances that have been deactivated will not be included in this array (if you have used a value from this array previously, it will now return the keyword <a href="../../../GML_Overview/Instance_Keywords.htm">noone</a>).</p>
+  <p>This <b>read-only</b> <a href="../../../GML_Overview/Arrays.htm">array</a> holds all the <a href="Instance_Variables/id.htm"><span class="inline">id</span>s</a> of every <em>active </em>instance within the room. This means that if you have used any of the <a href="Deactivating_Instances/Deactivating_Instances.htm">Instance Deactivate</a> functions those instances that have been deactivated will not be included in this array (if you have used a value from this array previously, it will now return the keyword <a href="../../../GML_Overview/Instance_Keywords.htm">noone</a>).</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code">instance_id[num];</p>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_ID_Instance">Instance ID</span></p>
+  <p class="code"><span data-keyref="Type_ID_Instance"><a href="Instance_Variables/id.htm" target="_blank">Object Instance</a></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">for (var i = 0; i &lt; instance_count; i ++;)<br />
@@ -39,7 +39,7 @@
         <div style="float:right">Next: <a href="instance_count.htm">instance_count</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 instance_id

--- a/Manual/contents/GameMaker_Language/GML_Reference/Strings/Strings.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Strings/Strings.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>Strings</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -126,7 +126,7 @@
     {invalid}<br />
     way to split a template across multiple lines&quot;;
   </p>
-  <h2 id="h3">toString() Method</h2>
+  <h2 id="tostring_method">toString() Method</h2>
   <p>When a reference to a struct or an instance of an object is passed as an argument to any of <span class="inline2"><a data-xref="{title}" href="string.htm">string</a></span> / <span class="inline2"><a data-xref="{title}" href="string_ext.htm">string_ext</a></span> / <span class="inline2"><a data-xref="{title}" href="../Debugging/show_debug_message.htm">show_debug_message</a></span> / <span class="inline2"><a data-xref="{title}" href="show_debug_message_ext.htm">show_debug_message_ext</a></span>, it will have its <span class="inline2">toString</span> method called, if it has one set.</p>
   <p class="code">toString = function()<br />
     {<br />
@@ -212,7 +212,7 @@
   </ul>
   <h3>Methods</h3>
   <ul class="Disc">
-    <li><a data-xref="{text}" href="Strings.htm#h3">toString() Method</a></li>
+    <li><a href="Strings.htm#tostring_method">toString Method</a></li>
   </ul>
   <h3>Related functions</h3>
   <ul class="Disc">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/Variable_Functions.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/Variable_Functions.htm
@@ -27,13 +27,13 @@
     <li><a href="variable_global_get.htm">variable_global_get</a></li>
     <li><a href="variable_global_set.htm">variable_global_set</a></li>
   </ul>
-  <h2>Info Functions</h2>
+  <h2 id="info_functions">Info Functions</h2>
   <p>The following functions provide general information about variables: </p>
   <ul class="colour">
     <li><a data-xref="{title}" href="nameof.htm">nameof</a></li>
     <li><a data-xref="{title}" href="typeof.htm">typeof</a></li>
   </ul>
-  <h2>Method Functions</h2>
+  <h2 id="method_functions">Method Functions</h2>
   <p>These next functions are all related to using <a href="../../GML_Overview/Method_Variables.htm">Method Variables</a>:</p>
   <ul class="colour">
     <li><a href="method.htm">method</a></li>
@@ -41,7 +41,7 @@
     <li><a href="method_get_index.htm">method_get_index</a></li>
     <li><a data-xref="{title}" href="method_call.htm">method_call</a></li>
   </ul>
-  <h2>Struct Functions</h2>
+  <h2 id="struct_functions">Struct Functions</h2>
   <p>The following functions are for use with structs:</p>
   <ul class="colour">
     <li><a data-xref="{title}" href="variable_struct_exists.htm">struct_exists</a></li>
@@ -60,7 +60,7 @@
     <li><a data-xref="{title}" href="variable_get_hash.htm">variable_get_hash</a></li>
     <li><a data-xref="{title}" href="variable_clone.htm">variable_clone</a></li>
   </ul>
-  <h2>Data Type Functions</h2>
+  <h2 id="data_type_functions">Data Type Functions</h2>
   <p>Finally, you also have the following functions for determining variable type (for more information on data types, please see <a data-xref="{title}" href="../../GML_Overview/Data_Types.htm">Data Types</a>, and see here for <a href="../../../Additional_Information/Type_Tables.htm">Type Tables</a>):</p>
   <ul class="colour">
     <li><a href="is_string.htm">is_string</a></li>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/static_get.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/static_get.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>static_get</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" type="text/css" href="../../../assets/css/default.css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Gurpreet S. Matharoo" />
@@ -15,9 +15,15 @@
 </head>
 <body>
   <h1><span data-field="title" data-format="default">static_get</span></h1>
-  <p>This function returns the static struct for the given function, or <span class="inline2">undefined</span> if it has no static. The static struct is where all static variables for a function are stored.</p>
-  <p>You can also supply a struct, in which case it will give you the static struct for the constructor that was used to create the struct (or it may be a different struct if it was changed using <span class="inline3_func"><a data-xref="{title}" href="static_set.htm">static_set</a></span>).</p>
-  <p>When using constructor inheritance, static structs are chained, i.e. you can get the static struct of a static struct, if the constructor has a parent constructor.</p>
+  <p>This function returns the static struct for the given function or struct.</p>
+  <p>When you supply a function, this function returns the static struct for the function.</p>
+  <p>You can also supply a struct. What&#39;s returned depends on the struct: </p>
+  <ul class="colour">
+    <li>For a struct created from a constructor using the <span class="inline2"><a data-xref="{title}" href="../../GML_Overview/Language_Features/new.htm">new</a></span> keyword: the static struct for the constructor that was used to create the struct (or a different struct if it was changed after creation using <span class="inline3_func"><a data-xref="{title}" href="static_set.htm">static_set</a></span>).</li>
+    <li>For a static struct: the parent static struct in the <a data-xref="{text}" href="../../GML_Overview/Structs/Static_Structs.htm#h">Static Chain</a>. When using constructor inheritance, static structs are chained, i.e. you can get the static struct of a static struct, if the constructor has a parent constructor.</li>
+    <li>For any other struct: this struct&#39;s &quot;parent&quot; struct, which links the struct to the &quot;root&quot; struct.</li>
+    <li>For the &quot;root&quot; struct: <span class="inline2">undefined</span></li>
+  </ul>
   <p>See: <a data-xref="{title}" href="../../GML_Overview/Structs/Static_Structs.htm">Static Struct</a></p>
   <p> </p>
   <h4>Syntax:</h4>
@@ -36,16 +42,16 @@
       </tr>
       <tr>
         <td>struct_or_func_name</td>
-        <td><span data-keyref="Type_Struct"><a href="../../../../GameMaker_Language/GML_Overview/Structs.htm" target="_blank">Struct</a></span> or <span data-keyref="Type_Function"><a href="../../../../GameMaker_Language/GML_Overview/Script_Functions.htm" target="_blank">Function</a></span></td>
+        <td><span data-keyref="Type_Struct"><a href="../../GML_Overview/Structs.htm" target="_blank">Struct</a></span> or <span data-keyref="Type_Function"><a href="../../GML_Overview/Script_Functions.htm" target="_blank">Function</a></span></td>
         <td>The struct or function for which to get the static struct</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Struct"><a href="../../../../GameMaker_Language/GML_Overview/Structs.htm" target="_blank">Struct</a></span> or <span data-keyref="Type_Undefined"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">undefined</a></span> if no static struct is set</p>
+  <p class="code"><span data-keyref="Type_Struct"><a href="../../GML_Overview/Structs.htm" target="_blank">Struct</a></span> or <span data-keyref="Type_Undefined"><a href="../../GML_Overview/Data_Types.htm" target="_blank">undefined</a></span> (for the root struct)</p>
   <p> </p>
-  <h4>Example:</h4>
+  <h4>Example 1:</h4>
   <p class="code">function counter() {<br />
         static count = 0;<br />
         return count ++;<br />
@@ -63,6 +69,23 @@
   <p>The above code creates a function <span class="inline2">counter()</span> with a static variable. The function is called repeatedly so its static variable&#39;s value is increased.</p>
   <p>The static struct for that function is then returned, and stored in a variable (<span class="inline2">_static_counter</span>). Then it prints the static variable from the function, by first reading it from the function directly (<span class="inline2">counter.count</span>) and then reading it from the static struct (<span class="inline2">_static_counter.count</span>). Both print the same value, as they refer to the exact same variable.</p>
   <p> </p>
+  <h4>Example 2: Going Up in the Static Chain</h4>
+  <p class="code">function item() constructor<br />
+    {<br />
+        static hello = function()<br />
+        {<br />
+            show_debug_message(&quot;Hello World!&quot;);<br />
+        }<br />
+    }<br />
+    function potion() : item() constructor {}<br />
+    <br />
+    my_potion = new potion();<br />
+    var _static_potion = <span data-field="title" data-format="default">static_get</span>(my_potion);<br />
+    var _static_parent = <span data-field="title" data-format="default">static_get</span>(_static_potion);<br />
+    _static_parent.hello();
+  </p>
+  <p>The above code first creates two constructors: a parent constructor <span class="inline2">item</span> with a single static function <span class="inline3_func">hello</span> and a child constructor <span class="inline2">potion</span>. It then creates a new <span class="inline2">potion</span> and stores it in a variable <span class="inline2">my_potion</span>. Next, a call to <span class="inline3_func"><span data-field="title" data-format="default">static_get</span></span> is made to get the static struct of <span class="inline2">my_potion</span>. The returned static struct, stored in a temporary variable <span class="inline2">_static_potion</span>, is part of the static chain. From this point, all further calls to <span class="inline3_func"><span data-field="title" data-format="default">static_get</span></span> will move up in the static chain. Another call to <span class="inline3_func"><span data-field="title" data-format="default">static_get</span></span> is made, which returns the static of <span class="inline2">item</span> and stores it in another temporary variable <span class="inline2">_static_parent</span>. Finally, this struct&#39;s <span class="inline3_func">hello</span> method is called.</p>
+  <p> </p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
@@ -71,7 +94,7 @@
         <div>Next: <a data-xref="{title}" href="static_set.htm">static_set</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 static_get

--- a/Manual/contents/IDE_Tools/The_Debugger.htm
+++ b/Manual/contents/IDE_Tools/The_Debugger.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>The Debugger</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../assets/css/default.css" type="text/css" />
   <script src="../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -17,6 +17,7 @@
   <h1><span data-field="title" data-format="default">The Debugger</span></h1>
   <p>The <strong>Debugger </strong>is a powerful tool for checking your game, and is especially useful for tracking down errors and bugs in your code, as well as checking that scripts are run when they should be, and that variables and arrays contain the values you expect, etc. You can start the Debugger by running your game from <span data-keyref="GameMaker Name">GameMaker</span> <a class="glossterm" data-glossterm="IDE" href="The_Debugger/The_Profiler.htm#">IDE</a> using the Debug button <img alt="Debug Icon" class="icon" src="../assets/Images/Icons/Icon_Debug.png" /> at the top of the IDE, or by going to the <a href="../IDE_Navigation/Menus/The_Build_Menu.htm">Build menu</a> and selecting &quot;<em>Debug</em>&quot;.</p>
   <p class="note"><span data-conref="../assets/snippets/Tag_note.hts"> </span> You may be prompted by Windows Firewall (or any other firewall program that you run) to create a security exception for this module. <strong>You must do this otherwise it will not work correctly</strong>. This is due to the way the Debugger works and is essential for debugging mobile platforms.</p>
+  <p class="note"><span data-conref="../assets/snippets/Tag_note.hts"> </span> On some systems you may see a very small memory increase due to the way that <span data-keyref="GameMaker Name">GameMaker</span> measures memory usage.</p>
   <p>When you run a game in debug mode, the IDE will display the different tools available for the Debugger:</p>
   <p><img alt="The Debugger Windows" class="center" src="../assets/Images/IDE Tools/Debug_Module.png" />The image shown above shows the default layout for the debugger, but as with other aspects of the IDE you can customise this to suit your needs, closing windows you don&#39;t need or changing the sizes of the docs and windows that you do need. You can reset the debugger layout at any time - or reopen closed windows - from the Debugger context menu at the top of the IDE:</p>
   <p><img alt="Debugger Context Menu" class="center" src="../assets/Images/IDE Tools/Debug_Module_Context_Menu.png" />Below we explain what each section of the debugger is for:</p>

--- a/Manual/contents/assets/snippets/Note_Warning_Static_Struct_Call_Once.hts
+++ b/Manual/contents/assets/snippets/Note_Warning_Static_Struct_Call_Once.hts
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
+  <meta name="topic-comment" content="A note that explains that you have to call the function at least once before attempting to access the static struct" />
+  <title>Note_Warning_Static_Struct_Call_Once</title>
+  <link rel="stylesheet" type="text/css" href="../css/default.css" />
+</head>
+<body>
+  <p class="note"><span data-conref="Tag_warning.hts"> </span> You can&#39;t access a static variable from a function that was never called, as static variables are initialised on the first call to a function. Trying to do so will give you an error and crash your game.</p>
+</body>
+</html>


### PR DESCRIPTION
- Changes to static (406d6f52648c6da09166be282f6a78bc09e09797): 
  - How the dot operator uses the static chain
  - Identically named variables in parent and child
  - Using the static chain to access a static of the parent
  - Described the "root" struct and how all structs connect to it
  - Updated `static_get` page accordingly
- Added note to debugger page (65cb5e241032056d25b8d801178f52d71b8ae712)