### PR TITLE
Various sample code changes and fixes

### DIFF
--- a/Manual/contents/Additional_Information/Bitwise_Operators.htm
+++ b/Manual/contents/Additional_Information/Bitwise_Operators.htm
@@ -153,10 +153,12 @@
     <p class="code">door_id = 1; // 0001</p>
     <p class="dropspot">The others would be something like:<br />
        </p>
-    <p class="code">door_id=2; // 0010<br />
-      door_id=4; // 0100<br />
-      door_id=8; // 1000<br />
-      etc...</p>
+    <p class="code">
+      door_id = 2; // 0010 <br />
+      door_id = 4; // 0100 <br />
+      door_id = 8; // 1000 <br />
+      // etc...
+    </p>
     <p class="dropspot">If we wanted the key to open door 1 and 3, then the key would have the MASK value of 5 (which is 101 in binary). If we perform an <span class="inline">AND</span> of this, and it comes out &quot;not zero&quot;, then we know that the key can open the door. You could also have keys that opened nothing by having a MASK of 0. See the code below for the actual check:</p>
     <p class="code">if ((key_id &amp; door_id) ! = 0)<br />
       {<br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Audio/audio_sound_gain.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Audio/audio_sound_gain.htm
@@ -52,18 +52,26 @@
   <p class="code"><span data-keyref="Type_Void">N/A</span></p>
   <p> </p>
   <h4>Example 1:</h4>
-  <p class="code">if val<br />
-    {<br />
-        var snd = audio_play_sound(snd_fountain, 10, true);<br />
-        <span data-field="title" data-format="default">audio_sound_gain</span>(snd, 0, 0);<br />
-        <span data-field="title" data-format="default">audio_sound_gain</span>(snd, 1, 5000);<br />
-    }</p>
-  <p>The above code checks a variable <span class="inline2">val</span>. If it returns <span class="inline">true</span> it will then assign the index of a sound to be played to the local variable <span class="inline2">snd</span>. This variable is then used to reduce the volume of that specific sound to 0 and fade up to full volume over 5 seconds.</p>
+  <p class="code">
+    var snd = audio_play_sound(snd_fountain, 10, true);                                     <br />
+    <span data-field="title" data-format="default">audio_sound_gain</span>(snd, 0, 0);      <br />
+    <span data-field="title" data-format="default">audio_sound_gain</span>(snd, 1, 5000);   <br />
+  </p>
+  <p>
+    The above code assigns the index of a sound to be played to the local variable <span class="inline2">snd</span>.
+    This variable is then used to reduce the volume of that specific sound to 0 and fade up to full volume over 5 seconds.
+  </p>
   <p> </p>
   <h4>Example 2:</h4>
-  <p class="code"><span data-field="title" data-format="default">audio_sound_gain</span>(snd_fountain, 0.5, 0);<br />
-    var snd = audio_play_sound(snd_fountain, 0, true, 2);</p>
-  <p>The above code first sets the gain of the sound asset &quot;snd_fountain&quot; to 0.5. It then plays this sound using <span class="inline2"><a data-xref="{title}" href="audio_play_sound.htm">audio_play_sound</a></span> and sets the gain of this new sound instance to 2 (using the optional &quot;gain&quot; parameter of the function).</p>
+  <p class="code">
+    <span data-field="title" data-format="default">audio_sound_gain</span>(snd_fountain, 0.5, 0);   <br />
+    var snd = audio_play_sound(snd_fountain, 0, true, 2);
+  </p>
+  <p>
+    The above code first sets the gain of the sound asset <span class="inline2">snd_fountain</span> to 0.5. 
+    It then plays this sound using <span class="inline2"><a data-xref="{title}" href="audio_play_sound.htm">audio_play_sound</a></span> 
+    and sets the gain of this new sound instance to 2 (using the optional &quot;gain&quot; parameter of the function).
+  </p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Sprites/Sprite_Manipulation/sprite_merge.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Sprites/Sprite_Manipulation/sprite_merge.htm
@@ -46,12 +46,14 @@
   <p class="code"><span data-keyref="Type_Void">N/A</span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code">var tspr;<br />
-    tspr[0] = spr_add(working_directory + &quot;Sprite Assets\explode1.png&quot;, 16, true, true, 0, 0);<br />
+  <p class="code">
+    var tspr = array_create(2);<br />
+    tspr[0] = sprite_add(working_directory + &quot;Sprite Assets/explode1.png&quot;, 16, true, true, 0, 0);<br />
     tspr[1] = sprite_duplicate(spr_Explosion);<br />
     sprite_merge(tspr[0], tspr[1]);<br />
     sprite_index = t_spr[0];<br />
-    sprite_delete(tspr[1]);</p>
+    sprite_delete(tspr[1]);
+  </p>
   <p>The above code loads a sprite into a local variable then merges it with another sprite that has been duplicated. Finally the merged sprite is assigned to the instance <span class="inline">sprite_index</span> while the loaded sprite is removed to free the memory it uses. Note that at some point after this operation, like in the Destroy or Room End events, you will also need to use <a href="sprite_delete.htm"><span class="inline">sprite_delete()</span></a> to remove the merged sprite from memory too.</p>
   <p> </p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Maths_And_Numbers/Angles_And_Distance/point_distance_3d.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Maths_And_Numbers/Angles_And_Distance/point_distance_3d.htm
@@ -61,7 +61,7 @@
   <h4>Example:</h4>
   <p class="code">var inst, ex, ey, ez;<br />
     inst = instance_nearest(x, y, enemy);<br />
-    if inst<br />
+    if (instance_exists(inst))<br />
     {<br />
         ex = inst.x;<br />
         ey = inst.y;<br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Movement_And_Collisions/Collisions/collision_rectangle.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Movement_And_Collisions/Collisions/collision_rectangle.htm
@@ -76,7 +76,7 @@
     inst = collision_rectangle(50, 50, 200, 100, obj_Ball, false, true);<br />
     if inst != noone<br />
     {<br />
-        with (inst) instance_destroy();<br />
+        instance_destroy(inst);<br />
     }</p>
   <p>This short code uses collision_rectangle check an area in the room from 50x, 50y (top left of the rectangle) to 200x, 200y (bottom right of the rectangle) for an instance of an object called &quot;obj_ball&quot;. It stores the return value in a temporary variable which is then checked to see if that value is an instance id, or the keyword <a href="../../../GML_Overview/Instance_Keywords.htm"><b>noone</b></a>. If it is <i>not</i> <b>noone</b> then it uses the stored instance id to destroy the object.</p>
   <p> </p>

--- a/Manual/contents/The_Asset_Editors/Object_Properties/Async_Events/Steam.htm
+++ b/Manual/contents/The_Asset_Editors/Object_Properties/Async_Events/Steam.htm
@@ -48,41 +48,40 @@
   <p>We will show an example of how downloading score data works by requesting the top ten ranking for the given leaderboard and parsing its results in the Steam Async Event (for uploading examples, please see the appropriate function pages). To start with we need to request the scores with the following code:</p>
   <p class="code">score_get = steam_download_scores(&quot;Game Scores&quot;, 1, 10);</p>
   <p>This will send off a request to the Steam Server for the scores from the leaderboard &quot;Game Scores&quot;, storing the async ID of the request in the variable &quot;<span class="inline">score_get</span>&quot;. This will then be handled in the <strong>Steam Async Event</strong> in the following way:</p>
-  <p class="code">var async_id = ds_map_find_value(async_load, &quot;id&quot;);<br />
-    if async_id == score_get<br />
-       {<br />
-       var entries = ds_map_find_value(async_load, &quot;entries&quot;);<br />
-       var map = json_decode(entries);<br />
-       if ds_map_exists(map, &quot;default&quot;)<br />
-        {<br />
-          ds_map_destroy(map);<br />
-          exit;<br />
-          }<br />
-       else<br />
-          {<br />
-          var list = ds_map_find_value(map, &quot;entries&quot;);<br />
-          var len = ds_list_size(list);<br />
-          var entry;<br />
-          for(var i = 0; i &lt; len; i++;)<br />
-             {<br />
-             entry = ds_list_find_value(list, i );<br />
-             steam_name[i] = ds_map_find_value(entry, &quot;name&quot;);<br />
-             steam_score[i] = ds_map_find_value(entry, &quot;score&quot;);<br />
-       steam_rank[i] = ds_map_find_value(entry, &quot;rank&quot;);<br />
-             if (ds_map_exists(entry, &quot;data&quot;))<br />
-                {<br />
-                var data = ds_map_find_value(entry, &quot;data&quot;);<br />
-                var buffId = buffer_base64_decode(data);<br />
-              var message = buffer_read(buffId, buffer_string);<br />
-                show_debug_message( &quot; -- attached message: &quot; + string(message));<br />
-                buffer_delete(buffId);<br />
-                }<br />
-             ds_map_destroy(entry);<br />
-           }<br />
-          ds_list_destroy(list)<br />
-          }<br />
-       ds_map_destroy(map)<br />
-       }</p>
+  <p class="code">
+    var async_id = ds_map_find_value(async_load, &quot;id&quot;);                                   <br/>
+    if (async_id == score_get)                                                                      <br/>
+    {                                                                                               <br/>
+        var entries = ds_map_find_value(async_load, &quot;entries&quot;);                           <br/>
+        var map = json_decode(entries);                                                             <br/>
+        if (ds_map_exists(map, &quot;default&quot;))                                                <br/>
+        {                                                                                           <br/>
+            ds_map_destroy(map);                                                                    <br/>
+            exit;                                                                                   <br/>
+        }                                                                                           <br/>
+        else {                                                                                      <br/>
+            var list = ds_map_find_value(map, &quot;entries&quot;);                                 <br/>
+            var len = ds_list_size(list);                                                           <br/>
+            for (var i = 0; i < len; i++)                                                           <br/>
+            {                                                                                       <br/>
+                var entry = ds_list_find_value(list, i);                                            <br/>
+                steam_name[i] = ds_map_find_value(entry, &quot;name&quot;);                         <br/>
+                steam_score[i] = ds_map_find_value(entry, &quot;score&quot;);                       <br/>
+                steam_rank[i] = ds_map_find_value(entry, &quot;rank&quot;);                         <br/>
+                if (ds_map_exists(entry, &quot;data&quot;)) {                                       <br/>
+                    var data = ds_map_find_value(entry, &quot;data&quot;);                          <br/>
+                    var buffId = buffer_base64_decode(data);                                        <br/>
+                    var message = buffer_read(buffId, buffer_string);                               <br/>
+                    show_debug_message(&quot; -- attached message: &quot; + string(message));       <br/>
+                    buffer_delete(buffId);                                                          <br/>
+                }                                                                                   <br/>
+                ds_map_destroy(entry);                                                              <br/>
+            }                                                                                       <br/>
+            ds_list_destroy(list);                                                                  <br/>
+        }                                                                                           <br/>
+        ds_map_destroy(map);                                                                        <br/>
+    }
+  </p>
   <p>What we do here is first check the &quot;<span class="inline">id</span>&quot; key of the special async_load map. If this value is the same as the value of the original callback function (stored in the &quot;<span class="inline">score_get</span>&quot; variable) we then continue to process the data. The first thing we do is parse the <span class="inline">async_load</span> DS Map for the key &quot;<span class="inline">entries</span>&quot; which will contain a JSON object containing the leaderboard data. This JSON object is then decoded (see <a href="../../../GameMaker_Language/GML_Reference/File_Handling/Encoding_And_Hashing/json_decode.htm"><span class="inline">json_decode()</span></a>) as another DS Map, and this new map ID is stored in the variable &quot;<span class="inline">map</span>&quot;.</p>
   <p>This map is checked for the key &quot;<span class="inline">default</span>&quot; and if that is found then the map is destroyed and the event is exited. If no &quot;<span class="inline">default</span>&quot; key is found, the code will then parse the map to extract the necessary information about the leaderboard, by first extracting a DS List from the &quot;<span class="inline">entries</span>&quot; key of the DS Map, and then looping through each entry of the list to get another DS Map with the <span class="inline">name</span>, <span class="inline">score</span> and <span class="inline">rank</span> of each entry. These values are then stored in arrays and then we check to see if there is an additional &quot;<span class="inline">data</span>&quot; key. If there is (ie: the score was uploaded with an additional data package) then we also parse that and send it to the compiler console for debugging, before destroying the buffer and then continuing on to destroy the map. Note that if the &quot; <span class="inline">data</span>&quot; key is included, it needs to be decoded using the <a href="../../../GameMaker_Language/GML_Reference/Buffers/buffer_base64_decode.htm"><span class="inline">buffer_base64_decode()</span></a> function before it can be correctly read.</p>
   <p>Once the loop has finished, the entries list is destroyed as is the map that it was taken from. There is no need to destroy the <span class="inline">async_load</span> DS Map as this is handled for you by <span data-keyref="GameMaker Name">GameMaker</span>.</p>


### PR DESCRIPTION
> [!NOTE]
> This is the first part of #89 which I'm breaking down into multiple as it should've been, and covers the "Misc" changes from that PR.

#### 1. **Removed unneeded `if` in `audio_sound_gain` example**
The example for this function had an if statement which didn't really seem to add anything to the point it was getting across, but did make the description slightly more complicated:

**Original**
```gml
if val
{
    var snd = audio_play_sound(snd_fountain, 10, true);
    audio_sound_gain(snd, 0, 0);
    audio_sound_gain(snd, 1, 5000);
}
```
> The above code checks a variable `val`. If it returns **true** it will then assign the index of a sound to be played to the local variable `snd`. This variable is then used to reduce the volume of that specific sound to 0 and fade up to full volume over 5 seconds.

**Modified**
```gml
var snd = audio_play_sound(snd_fountain, 10, true);
audio_sound_gain(snd, 0, 0);
audio_sound_gain(snd, 1, 5000);
```
> The above code assigns the index of a sound to be played to the local variable `snd`. This variable is then used to reduce the volume of that specific sound to 0 and fade up to full volume over 5 seconds.

#### 2. Fixed formatting on "**Async Events - Steam**" example:
The original used 3 spaces for indents, so changed that to 4 for consistency.

I was also thinking about swapping out `json_decode` for the newer `json_parse`, but that's probably out of the scope of what this PR should be.

#### 3. Fixed `sprite_merge` example calling "`spr_add`":
This one's pretty self-explanatory:
```diff
- tspr[0] = spr_add(working_directory + "Sprite Assets\explode1.png", 16, true, true, 0, 0);
+ tspr[0] = sprite_add(working_directory + "Sprite Assets/explode1.png", 16, true, true, 0, 0);
```

#### 4. Consistent whitespace on `door_id` example for "**Bitwise Operators**":
```diff
door_id = 1; // 0001

- door_id=2; // 0010
- door_id=4; // 0100
- door_id=8; // 1000
- etc...

+ door_id = 2; // 0010
+ door_id = 4; // 0100
+ door_id = 8; // 1000
+ // etc...
```

#### 5. Fixed checking instance exists for `point_distance_3d` example:
I was tossing up whether to use `!= noone` or `instance_exists` for this, but the other manual pages seemed to show a preference for `instance_exists`, so used that:
```diff
var inst = instance_nearest(x, y, enemy);
- if inst
- {
+ if (instance_exists(inst))
+ {
```

#### 6. Removed unneeded `with` for `collision_rectangle` example:
```diff
- with (inst) instance_destroy();
+ instance_destroy(inst);
```
`instance_destroy()` now accepts an argument for which instance, so this isn't needed anymore.