### PR TITLE
a sundry small fixes, mostly linkage errors!

### DIFF
--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/Gamepad_Input.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/Gamepad_Input.htm
@@ -28,7 +28,7 @@
     </colgroup>
     <tbody>
       <tr>
-        <th colspan="2"><span data-keyref="Type_Constant_Gamepad_Axis"><a href="gamepad_axis_value.htm" target="_blank">Gamepad Axis Constant</a></span></th>
+        <th colspan="2"><span data-keyref="Type_Constant_Gamepad_Axis" id="Gamepad_Axis_Constants">Gamepad Axis Constant</span></th>
       </tr>
       <tr>
         <th>Constant</th>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_axis_count.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_axis_count.htm
@@ -31,17 +31,17 @@
         <th>Description</th>
      </tr>
       <tr>
-        <td>device</td><td><span data-keyref="Type_Real"></span></td>
+        <td>device</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
      </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Real"></span></p>
+  <p class="code"><span data-keyref="Type_Real">Real</span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code">axis = gamepad_axis_count(0))</p>
+  <p class="code">axis = gamepad_axis_count(0);</p>
   <p>The above code stores the number of axes available for the gamepad connected to device &quot;slot&quot; 0 in the variable &quot;axis&quot;.</p>
   <p> </p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_axis_value.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_axis_value.htm
@@ -36,7 +36,7 @@
       <tr>
         <td>axisIndex</td>
         <td><span data-keyref="Type_Constant_Gamepad_Axis">Gamepad Axis Constant</span></td>
-        <td>The axis index to check (see the <a href="Gamepad_Input.htm">constants list</a>).</td>
+        <td>The axis index to check (see the <a href="Gamepad_Input.htm#Gamepad_Axis_Constant">constants list</a>).</td>
       </tr>
     </tbody>
   </table>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_button_check.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_button_check.htm
@@ -29,24 +29,24 @@
       </tr>
       <tr>
         <td>device</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
       </tr>
       <tr>
         <td>button</td>
-        <td><span data-keyref="Type_Constant_Gamepad_Button"><a href="../../../../../GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_axis_value.htm" target="_blank">Gamepad Button Constant</a></span></td>
-        <td>Which gamepad button <a href="Gamepad_Input.htm">constant</a> to check for.</td>
+        <td><span data-keyref="Type_Constant_Gamepad_Button">Gamepad Button Constant</span></td>
+        <td>Which gamepad button <a href="Gamepad_Input.htm#Gamepad_Button_Constant">constant</a> to check for.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
+  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">if <span data-field="title" data-format="default">gamepad_button_check</span>(0, gp_face1)<br />
     {<br />
-        if (canshoot = true) <br />
+        if (canshoot == true) <br />
         {<br />
             audio_play_sound(snd_Shoot, 0, false);<br />
             instance_create_layer(x, y, &quot;Bullets&quot;, obj_Bullet)<br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_button_check_pressed.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_button_check_pressed.htm
@@ -36,7 +36,7 @@
       <tr>
         <td>button</td>
         <td><span data-keyref="Type_Constant_Gamepad_Button">Gamepad Button Constant</span></td>
-        <td>Which gamepad button <a href="Gamepad_Input.htm">constant</a> to check for.</td>
+        <td>Which gamepad button <a href="Gamepad_Input.htm#Gamepad_Button_Constant">constant</a> to check for.</td>
       </tr>
     </tbody>
   </table>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_button_check_released.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_button_check_released.htm
@@ -35,7 +35,7 @@
       <tr>
         <td>button</td>
         <td><span data-keyref="Type_Constant_Gamepad_Button">Gamepad Button Constant</span></td>
-        <td>Which gamepad button <a href="Gamepad_Input.htm">constant</a> to check for.</td>
+        <td>Which gamepad button <a href="Gamepad_Input.htm#Gamepad_Button_Constant">constant</a> to check for.</td>
       </tr>
     </tbody>
   </table>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_button_count.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_button_count.htm
@@ -31,14 +31,14 @@
         <th>Description</th>
      </tr>
       <tr>
-        <td>device</td><td><span data-keyref="Type_Real"></span></td>
+        <td>device</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
      </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Real"></span></p>
+  <p class="code"><span data-keyref="Type_Real">Real</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">b_num = gamepad_button_count(0);</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_button_value.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_button_value.htm
@@ -30,19 +30,19 @@
       </tr>
       <tr>
         <td>device</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
       </tr>
       <tr>
         <td>button</td>
-        <td><span data-keyref="Type_Constant_Gamepad_Button"><a href="../../../../../GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_axis_value.htm" target="_blank">Gamepad Button Constant</a></span></td>
-        <td>Which gamepad button <a href="Gamepad_Input.htm">constant</a> to check for.</td>
+        <td><span data-keyref="Type_Constant_Gamepad_Button">Gamepad Button Constant</span></td>
+        <td>Which gamepad button <a href="Gamepad_Input.htm#Gamepad_Button_Constant">constant</a> to check for.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></p>
+  <p class="code"><span data-keyref="Type_Real">Real</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">speed = gamepad_button_value(0, gp_shoulderrb) * 4;</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_axis_deadzone.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_axis_deadzone.htm
@@ -27,14 +27,14 @@
         <th>Description</th>
      </tr>
       <tr>
-        <td>device</td><td><span data-keyref="Type_Real"></span></td>
+        <td>device</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
      </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Real"></span></p>
+  <p class="code"><span data-keyref="Type_Real">Real</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">if (gamepad_get_axis_deadzone(global.PadId) != 0.5) <br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_button_threshold.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_button_threshold.htm
@@ -27,14 +27,14 @@
         <th>Description</th>
      </tr>
       <tr>
-        <td>device</td><td><span data-keyref="Type_Real"></span></td>
+        <td>device</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
      </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Real"></span></p>
+  <p class="code"><span data-keyref="Type_Real">Real</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">if (gamepad_get_button_threshold(0) != 0.5) <br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_description.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_description.htm
@@ -27,14 +27,14 @@
         <th>Description</th>
      </tr>
       <tr>
-        <td>device</td><td><span data-keyref="Type_Real"></span></td>
+        <td>device</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad &quot;slot&quot; to get the name of.</td>
      </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_String"></span></p>
+  <p class="code"><span data-keyref="Type_String">String</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">var gp_num = gamepad_get_device_count();<br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_device_count.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_device_count.htm
@@ -23,7 +23,7 @@
   <p class="code">gamepad_get_device_count();</p>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></p>
+  <p class="code"><span data-keyref="Type_Real">Real</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">var gp_num = gamepad_get_device_count();<br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_guid.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_guid.htm
@@ -53,14 +53,14 @@
         </tr>
         <tr>
           <td>index</td>
-          <td><span data-keyref="Type_Real"></span></td>
+          <td><span data-keyref="Type_Real">Real</span></td>
           <td>Which gamepad &quot;slot&quot; index to check</td>
         </tr>
       </tbody>
     </table>
     <p> </p>
     <h4>Returns:</h4>
-    <p class="code"><span data-keyref="Type_String"></span></p>
+    <p class="code"><span data-keyref="Type_String">String</span></p>
     <p> </p>
     <h4>Example:</h4>
     <p class="code">var _guid = gamepad_get_guid(global.PadIndex);

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_mapping.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_mapping.htm
@@ -40,14 +40,14 @@
         <th>Description</th>
      </tr>
       <tr>
-        <td>index</td><td><span data-keyref="Type_Real"></span></td>
+        <td>index</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad index &quot;slot&quot; to get the mapping from.</td>
      </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_String"></span></p>
+  <p class="code"><span data-keyref="Type_String">String</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">var _gpMap = gamepad_get_mapping(global.PadIndex);<br/> show_debug_message(&quot;Gamepad Mapping = &quot; + _gpMap);</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_option.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_get_option.htm
@@ -49,11 +49,11 @@
         <th>Description</th>
      </tr>
       <tr>
-        <td>device</td><td><span data-keyref="Type_Real"></span></td>
+        <td>device</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
      </tr>
       <tr>
-        <td>option_name</td><td><span data-keyref="Type_String"></span></td>
+        <td>option_name</td><td><span data-keyref="Type_String">String</span></td>
         <td>The name of the option to get the value from (a string, see the table above)</td>
      </tr>
     </tbody>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_hat_count.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_hat_count.htm
@@ -30,14 +30,14 @@
       </tr>
       <tr>
         <td>device</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></p>
+  <p class="code"><span data-keyref="Type_Real">Real</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">h_num = gamepad_hat_count(4);</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_hat_value.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_hat_value.htm
@@ -38,32 +38,36 @@
       </tr>
       <tr>
         <td>device</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
       </tr>
       <tr>
         <td>hatindex</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad hat (or hats) to check for (a value from 0 to <span class="inline2"><a data-xref="{title}" href="gamepad_hat_count.htm">gamepad_hat_count</a>(device) - 1</span>)</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span> (hat value as a bitmask)</p>
+  <p class="code"><span data-keyref="Type_Real">Real</span> (hat value as a bitmask)</p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">var _dir = <span data-field="title" data-format="default">gamepad_hat_value</span>(global.PadIndex, 0);<br />
     switch (_dir)<br />
     {<br />
-        case 1: y -= 3; break;<br />
-        case 2: x += 3; break;<br />
-        case 3: y -= 3; x += 3; break;<br />
-        case 4: x -= 3; break;<br />
-        case 6: y += 3; x += 3; break;<br />
-        case 8: y += 3; break;<br />
-        case 9: y -= 3; x -= 3; break;<br />
-        case 12: y += 3; x -= 3; break;<br />
+        case 1:<br />
+            y -= 3;<br />
+        break;<br />
+        case 2:<br />
+            x += 3;<br />
+        break;<br />
+        case 4:<br />
+            y += 3;<br />
+        break;<br />
+        case 8:<br />
+            x -= 3;<br />
+        break;<br />
     }</p>
   <p>The above code stores the state of the hat with index 0 on gamepad device slot <span class="inline2">global.PadIndex</span> in a local variable <span class="inline2">_dir</span>, then checks to see what the returned hat value is and acts accordingly.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_is_connected.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_is_connected.htm
@@ -30,23 +30,27 @@
       </tr>
       <tr>
         <td>device</td>
-        <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad &quot;slot&quot; to check.</td>
       </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></p>
+  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">var gp_num = gamepad_get_device_count();<br />
     for (var i = 0; i &lt; gp_num; i++)<br />
     {<br />
-        if gamepad_is_connected(i)<br />
-            global.gp[i] = true<br />
+        if (gamepad_is_connected(i))<br />
+        {<br />
+            global.gp[i] = true;<br />
+        }<br />
         else<br />
+        {<br />
             global.gp[i] = false;<br />
+        }<br />
     }</p>
   <p>The above code loops through the available gamepads (or gamepad slots) and then checks each one for a connected gamepad. The returned value is then used to set a global array to <span class="inline">true</span> or <span class="inline">false</span> for use in future checks.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_is_supported.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_is_supported.htm
@@ -26,7 +26,7 @@
   <p class="code">gamepad_is_supported();</p>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Bool"></span></p>
+  <p class="code"><span data-keyref="Type_Bool">Boolean</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">global.GP = gamepad_is_supported();</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_remove_mapping.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_remove_mapping.htm
@@ -26,14 +26,14 @@
         <th>Description</th>
      </tr>
       <tr>
-        <td>index</td><td><span data-keyref="Type_Real"></span></td>
+        <td>index</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad index &quot;slot&quot; to remove the mapping from.</td>
      </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Void"></span></p>
+  <p class="code"><span data-keyref="Type_Void">N/A</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">if (remap == true) <br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_set_axis_deadzone.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_set_axis_deadzone.htm
@@ -30,18 +30,18 @@
         <th>Description</th>
      </tr>
       <tr>
-        <td>device</td><td><span data-keyref="Type_Real"></span></td>
+        <td>device</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
      </tr>
       <tr>
-        <td>deadzone</td><td><span data-keyref="Type_Real"></span></td>
+        <td>deadzone</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>The dead zone value from 0 to 1.</td>
      </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Void"></span></p>
+  <p class="code"><span data-keyref="Type_Void">N/A</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_set_button_threshold.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_set_button_threshold.htm
@@ -30,12 +30,12 @@
       </tr>
       <tr>
         <td>device</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
       </tr>
       <tr>
         <td>threshold</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>The new threshold value (from 0 - 1, default 0.5).</td>
       </tr>
     </tbody>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_set_colour.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_set_colour.htm
@@ -26,18 +26,18 @@
         <th>Description</th>
      </tr>
       <tr>
-        <td>device</td><td><span data-keyref="Type_Real"></span></td>
+        <td>device</td><td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to set.</td>
      </tr>
       <tr>
-        <td>colour</td><td><span data-keyref="Type_Constant_Colour"></span></td>
+        <td>colour</td><td><span data-keyref="Type_Constant_Colour">Colour</span></td>
         <td>The colour to use.</td>
      </tr>
     </tbody>
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Void"></span></p>
+  <p class="code"><span data-keyref="Type_Void">N/A</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">if (health &lt; 10) <br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_set_vibration.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_set_vibration.htm
@@ -29,17 +29,17 @@
       </tr>
       <tr>
         <td>device</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>Which gamepad device &quot;slot&quot; to check.</td>
       </tr>
       <tr>
         <td>left_motor</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>The amount of vibration from the left motor from 0 to 1.</td>
       </tr>
       <tr>
         <td>right_motor</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real">Real</span></td>
         <td>The amount of vibration from the right motor from 0 to 1.</td>
       </tr>
     </tbody>

--- a/Manual/contents/assets/snippets/Gamepad_button_constants.hts
+++ b/Manual/contents/assets/snippets/Gamepad_button_constants.hts
@@ -12,7 +12,7 @@
   <table>
     <tbody>
       <tr>
-        <th colspan="2"><span data-keyref="Type_Constant_Gamepad_Button"><a href="../../GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_axis_value.htm" target="_blank">Gamepad Button Constant</a></span></th>
+        <th colspan="2"><span data-keyref="Type_Constant_Gamepad_Button" id="Gamepad_Button_Constant">Gamepad Button Constant</span></th>
       </tr>
       <tr>
         <th>Constant</th>

--- a/Manual/variable/Default.var
+++ b/Manual/variable/Default.var
@@ -627,14 +627,14 @@
 <keydef keys="Type_Constant_Gamepad_Axis">
 	<topicmeta>
 		<keywords>
-			<keyword>&lt;a target=&quot;_blank&quot; href=&quot;contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_axis_value.htm&quot;&gt;Gamepad Axis Constant&lt;/a&gt;</keyword>
+			<keyword>&lt;a target=&quot;_blank&quot; href=&quot;contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/Gamepad_Input.htm&quot;&gt;Gamepad Axis Constant&lt;/a&gt;</keyword>
 		</keywords>
 	</topicmeta>
 </keydef>
 <keydef keys="Type_Constant_Gamepad_Button">
 	<topicmeta>
 		<keywords>
-			<keyword>&lt;a target=&quot;_blank&quot; href=&quot;contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/gamepad_axis_value.htm&quot;&gt;Gamepad Button Constant&lt;/a&gt;</keyword>
+			<keyword>&lt;a target=&quot;_blank&quot; href=&quot;contents/GameMaker_Language/GML_Reference/Game_Input/GamePad_Input/Gamepad_Input.htm&quot;&gt;Gamepad Button Constant&lt;/a&gt;</keyword>
 		</keywords>
 	</topicmeta>
 </keydef>


### PR DESCRIPTION
## overall changes:
  - Default.var had the same, wrong link for both Type_Constant_Gamepad_Button and Type_Constant_Gamepad_Axis, fixed that up!
  - some pages had direct links to the gamepad axis value function page despite needing to have a link to Gamepad_Input.htm
  - many pages had extraneous links for data type span tags or had empty span tags entirely; extraneous links were removed and empty tags were filled to ensure html validation on those pages passes and that the tags do not cause accessibility software to fail.
  - small typo fixes to some code blocks

## specific changes:
  - the switch case example for gamepad_hat_value() was not formatted using the same example from the page about switch statements. formatting it the right way caused the code example to really balloon so i truncated the example to just the four cardinal directions. the values also did not line up with the binary literal values of the return so i fixed 'em.
  - i placed anchors in the constants headers for the table on Gamepad_Input.htm, then changed the links to gamepad and axis constants in argument descriptions to include these anchors, allowing manual readers to go directly to the constant list when doing very quick lookups.

### suggestions for the manual overall:
  - the empty span tags are a nuisance and the manual is not consistently using empty or none empty tags, and many are doubled with anchor links. probably from people editing the manual offline and adding the links manually. this should get cleaned up because empty span tags throw off screen readers, and offline manual users just get blank datatype fields instead.