### PR TITLE
Fix typo in audio_sound_loop_start.htm

### DIFF
--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Loop_Points/audio_sound_loop_start.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Loop_Points/audio_sound_loop_start.htm
@@ -52,7 +52,7 @@
   <h4>Example:</h4>
   <p class="code"><span data-field="title" data-format="default">audio_sound_loop_start</span>(snd_machine, 4);<br />
     audio_sound_loop_end(snd_machine, 10);<br />
-    ins_sound = audio_play_sound(snd_snd_machine, 100, true);</p>
+    ins_sound = audio_play_sound(snd_machine, 100, true);</p>
   <p>The above code sets the loop start point for the existing sound asset <span class="inline2">snd_machine</span> to 4 seconds and the loop end point to 10 seconds. The sound is then played with a priority of 100 and <span class="inline2">loop</span> set to <span class="inline2">true</span>. The new sound <em>instance</em> gets its loop start and end position from the sound <em>asset</em>. Its ID is stored in a variable <span class="inline2">ins_sound</span>.</p>
   <p> </p>
   <p> </p>


### PR DESCRIPTION
ins_sound tries to play "snd_snd_machine" instead of "snd_machine" which the audio_loop_start and audio_loop_end refer to, this fixes that issue.