### PR TITLE
Improvements to asynchronous HTTP function pages, game_restart() now clears existing call_later() time sources

### DIFF
--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/HTTP.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/HTTP.htm
@@ -15,19 +15,70 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">HTTP</span></h1>
-  <p>This section lists the different Asynchronous HTTP functions available in <span data-keyref="GameMaker Name">GameMaker</span>. These functions will generate an <a href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">Asynchronous HTTP Event</a> in all instances that have it:</p>
+  <p>This section lists the different Asynchronous HTTP functions available in <span data-keyref="GameMaker Name">GameMaker</span>.</p>
+  <p>HTTP stands for <a href="https://en.wikipedia.org/wiki/HTTP">Hypertext Transfer Protocol</a>, which is a protocol for communication on the World Wide Web. It is used when you browse the internet using a web browser, download files, log in to a website, interact with RESTful APIs, ... It has a variant named HTTPS (S indicating &quot;Secure&quot;).</p>
+  <p>HTTP <em>requests</em> are sent to a web server, which replies by sending back a <em>response</em>. A request uses one of several <em>methods</em>, of which GET and POST are the most common ones. Both the request and response may contain headers (a collection of key-value pairs) and a request body (the actual data to send). The response contains a status code indicating the status and can contain data (e.g. file contents).</p>
+  <p><span data-keyref="GameMaker Name">GameMaker</span> lets you create and send HTTP requests using the functions on this page. The response is returned in an <a href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">Asynchronous HTTP Event</a> in all instances that have it.</p>
+  <h2 id="request_functions">Request Functions</h2>
+  <p>The most general function is <span class="inline3_func"><a data-xref="{title}" href="http_request.htm">http_request</a></span>, which allows you to specify any request method as well as headers and data.</p>
+  <p>The other functions can be used for more specific requests:</p>
   <ul class="colour">
-    <li><a data-xref="{title}" href="http_request.htm">http_request</a></li>
-    <li><a data-xref="{title}" href="http_get.htm">http_get</a></li>
-    <li><a data-xref="{title}" href="http_get_file.htm">http_get_file</a></li>
-    <li><a data-xref="{title}" href="http_post_string.htm">http_post_string</a></li>
+    <li><span class="inline3_func"><a data-xref="{title}" href="http_get.htm">http_get</a></span> for a GET request</li>
+    <li><span class="inline3_func"><a data-xref="{title}" href="http_get_file.htm">http_get_file</a></span> to download a file using GET</li>
+    <li><span class="inline3_func"><a data-xref="{title}" href="http_post_string.htm">http_post_string</a></span> to make a HTTP request using POST</li>
   </ul>
-  <p>Note that: </p>
+  <h3 id="urls">URLs</h3>
+  <p>All request functions take a URL. The URL string: </p>
   <ul class="colour">
-    <li>You can use an IP address in the <span class="inline2">url</span> parameter of all these functions, e.g. <span class="inline2">&quot;http://1.1.1.1&quot;</span>.</li>
-    <li>The URL string must include the protocol, e.g. <span class="inline2">&quot;http://www.google.com&quot;</span> or <span class="inline2">&quot;https://www.google.com&quot;</span>.</li>
+    <li>must include the protocol, e.g. <span class="inline2">&quot;http://www.google.com&quot;</span> or <span class="inline2">&quot;https://www.google.com&quot;</span>.</li>
+    <li>can contain an IP address, e.g. <span class="inline2">&quot;http://1.1.1.1&quot;</span>.</li>
+    <li>can contain <a href="https://en.wikipedia.org/wiki/Query_string">query parameters</a>, e.g. <span class="inline2">&quot;http://www.example.com/examples?example_id={id}&quot;</span>.</li>
   </ul>
-  <h2>Connection Timeout</h2>
+  <h2 id="making_requests">Making Requests</h2>
+  <p>Let&#39;s look at how a general HTTP request is handled from start to end:</p>
+  <p class="code_heading">Mouse Left Pressed Event</p>
+  <p class="code">var _map_headers = ds_map_create();<br />
+    request_id = http_request(&quot;http://www.google.com&quot;, &quot;GET&quot;, _map_headers, &quot;&quot;);<br />
+    ds_map_destroy(_map_headers);</p>
+  <p class="code_heading">Async - HTTP Event</p>
+  <p class="code">if (async_load[? &quot;id&quot;] != request_id) { exit; }<br />
+    <br />
+    var _status = async_load[? &quot;status&quot;];<br />
+    if (_status &lt; 0)<br />
+    {<br />
+        // Error occurred<br />
+        <br />
+        exit;<br />
+    }<br />
+    <br />
+    if (_status == 1)<br />
+    {<br />
+        // Downloading<br />
+        <br />
+        exit;<br />
+    }<br />
+    <br />
+    if (_status == 0)<br />
+    {<br />
+        // Request completed!<br />
+        <br />
+        if (async_load[? &quot;http_status&quot;] == 200)<br />
+        {<br />
+            // Request was succesful<br />
+            <br />
+        }<br />
+    }
+  </p>
+  <p>In, for example, a Mouse Left Pressed Event the function <span class="inline3_func"><a data-xref="{title}" href="http_request.htm">http_request</a></span> is called. The request uses the <span class="inline2">&quot;GET&quot;</span> method to retrieve a webpage. No headers are passed and the request body is set to an empty string <span class="inline2">&quot;&quot;</span>.</p>
+  <p>The <a href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">Async HTTP event</a> is then triggered one or more times. In this event, the <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span>&#39;s <span class="inline2">&quot;id&quot;</span> key is first checked to see if it matches the <span class="inline2">request_id</span> stored earlier. If not, this event is not for the request made earlier and the code is exited. Next, the <span class="inline2">&quot;status&quot;</span> key is checked. This can hold one of three values: </p>
+  <ul class="colour">
+    <li>&lt; 0 : error</li>
+    <li>0 : request completed</li>
+    <li>1 : content is being downloaded</li>
+  </ul>
+  <p>While downloading content, the event will trigger multiple times, during which the <span class="inline2">&quot;status&quot;</span> key will hold the value 1. Finally, it runs a last time and <span class="inline2">async_load[?&quot;status&quot;]</span> will hold 0 or &lt; 0.</p>
+  <p>The last time the event triggers for this request, the <span class="inline2">&quot;status&quot;</span> key will hold 0. This value indicates the request has completed. The HTTP status is then checked. If it is 200 (indicating &quot;success&quot;), the data can be found in <span class="inline2">async_load[?&quot;result&quot;]</span>.</p>
+  <h2 id="connection_timeout">Connection Timeout</h2>
   <p>The asynchronous HTTP functions send a request to a server, which might take some time to respond. If the server takes too long to respond, the connection may time out. In <span data-keyref="GameMaker Name">GameMaker</span> this happens after <span data-keyref="HTTP_Timeout_Default">60000</span> ms by default.</p>
   <p>The following two functions can be used to get and change this value: </p>
   <ul class="colour">
@@ -43,6 +94,24 @@
     <li><a data-xref="{title}" href="http_set_request_crossorigin.htm">http_set_request_crossorigin</a></li>
   </ul>
   <p>In most cases these functions should not need to be used, but if the game is stored on a secured server - where certain assets may require basic authentication to be accessed and are generating security errors when loading - setting the cross-origin type for image requests to <span class="inline2">&quot;use-credentials&quot;</span> may be necessary (as opposed to the default <span class="inline2">&quot;anonymous&quot;</span> setting).</p>
+  <h2 id="func_ref">Function Reference</h2>
+  <h3>Requests</h3>
+  <ul class="colour">
+    <li><a data-xref="{title}" href="http_request.htm">http_request</a></li>
+    <li><a data-xref="{title}" href="http_get.htm">http_get</a></li>
+    <li><a data-xref="{title}" href="http_get_file.htm">http_get_file</a></li>
+    <li><a data-xref="{title}" href="http_post_string.htm">http_post_string</a></li>
+  </ul>
+  <h3>Timeouts</h3>
+  <ul class="colour">
+    <li><a data-xref="{title}" href="http_get_connect_timeout.htm">http_get_connect_timeout</a></li>
+    <li><a data-xref="{title}" href="http_set_connect_timeout.htm">http_set_connect_timeout</a></li>
+  </ul>
+  <h3>Cross-Domain</h3>
+  <ul class="colour">
+    <li><a data-xref="{title}" href="http_get_request_crossorigin.htm">http_get_request_crossorigin</a></li>
+    <li><a data-xref="{title}" href="http_set_request_crossorigin.htm">http_set_request_crossorigin</a></li>
+  </ul>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_get.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_get.htm
@@ -15,11 +15,10 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">http_get</span></h1>
-  <p>This function connects to the specified URL in order to retrieve information.</p>
-  <p>As this is an asynchronous function, <span data-keyref="GameMaker Name">GameMaker</span> will not block while waiting for a reply, but will keep on running unless it gets callback information. This information will be in the form of a string and will trigger an <b>Async HTTP Event</b> in any instance that has one defined in its object events. You should also note that HTTP request parameters (the bits sometimes &quot;tacked on&quot; to the end of a URL when you submit a form on a web page) are perfectly acceptable when using this function, for example:</p>
-  <p class="code"><span data-field="title" data-format="default">http_get</span>(&quot;http://www.example.com/logon?username={name}&quot;);</p>
-  <p>will pass the string held in the variable <span class="inline2">name</span> to the server as well as retrieve the data from that URL. So, essentially, any time a simple, short piece of data needs to be passed from the client to the server, this would be a reasonable choice as the function to use.</p>
+  <p>This function sends a GET request to the specified URL in order to retrieve information.</p>
+  <p>This is an asynchronous function, so <span data-keyref="GameMaker Name">GameMaker</span> will not block while waiting for a reply, but will keep on running unless it gets callback information. This information will be in the form of a string and will trigger an <b>Async HTTP Event</b> in any instance that has one defined in its object events.</p>
   <div data-conref="../../../../assets/snippets/Note_HTTP_Requests_CrossOrigin.hts"> </div>
+  <h2>Async Callback</h2>
   <p>This function will generate multiple &quot;callbacks&quot; which are picked up by any <a href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">HTTP Events</a>. These will generate a <span data-keyref="Type_ID_DS_Map"><a href="../../Data_Structures/DS_Maps/ds_map_create.htm" target="_blank">DS Map</a></span> (more commonly known as a &quot;dictionary&quot;) that is exclusive to this event and is stored in the special variable <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span>. This DS map will contain different values depending on whether there is data being returned or not. For example, if you have requested a file, the event will trigger multiple times as each packet of data is received so that you can show a progress bar, for example.</p>
   <div data-conref="../../../../assets/snippets/Note_HTTP_async_load_Contents.hts"> </div>
   <p> </p>
@@ -35,7 +34,7 @@
       <tr>
         <td>url</td>
         <td><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
-        <td>The web address of the server that you wish to get information from</td>
+        <td>The web address of the server that you wish to get information from. See <a data-xref="{text}" href="HTTP.htm#urls">URLs</a></td>
       </tr>
     </tbody>
   </table>
@@ -43,17 +42,17 @@
   <h4>Returns:</h4>
   <p class="code"><span data-keyref="Type_ID_Async_Event"><a href="../Asynchronous_Functions.htm" target="_blank">Async Request ID</a></span> (or -1 if something went wrong)</p>
   <p> </p>
-  <h4>Extended Example:</h4>
-  <p>The <span class="inline3_func"><span data-field="title" data-format="default">http_get</span></span> function can be called from any event, and since it&#39;s asynchronous the callback can be almost instantaneous or could take several seconds. Calling the function is simple and would look something like this:</p>
-  <p class="code">request_id = http_get(&quot;http://www.MacSweeneyGames.com/logon?username={name}&quot;);</p>
+  <h4>Example:</h4>
+  <p>The <span class="inline3_func"><span data-field="title" data-format="default">http_get</span></span> function can be called from any event, and since it&#39;s asynchronous the callback can be almost instantaneous or could take several seconds. Calling the function is simple and looks something like this:</p>
+  <p class="code">request_id = http_get($&quot;http://www.MacSweeneyGames.com/logon?username={name}&quot;);</p>
   <p>The above code will pass the string held in the variable <span class="inline2">name</span> to the given server as well as retrieve the data from that URL, triggering an Async Event which will contain the <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span> DS map (the <span class="inline2">async_load</span> map index will be stored in the variable <span class="inline2">request_id</span> so you can check for the correct callback). The Async Event triggered would be the <a data-xref="{title}" href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">HTTP</a> sub-event, and in that event you would have the following:</p>
   <p class="code_heading">Async HTTP Event</p>
-  <p class="code">if (ds_map_find_value(async_load, &quot;id&quot;) == request_id)<br />
+  <p class="code">if (async_load[? &quot;id&quot;] == request_id)<br />
     {<br />
         var _status = async_load[? &quot;status&quot;];<br />
         var _r_str = (_status == 0) ? async_load[? &quot;result&quot;] : &quot;null&quot;;<br />
     }</p>
-  <p>The above code first checks the ID of the async request, then assigns a value to <span class="inline2">_r_str</span> depending on the <span class="inline2">&quot;status&quot;</span> of the callback. If the value is equal to 0 (signalling success), the result from the callback is stored in a variable for future use, otherwise the variable is set to a default value (in this case <span class="inline2">&quot;null&quot;</span>).</p>
+  <p>The above code first checks the ID of the async request, then assigns a value to <span class="inline2">_r_str</span> depending on the <span class="inline2">&quot;status&quot;</span> of the callback. If the value is equal to 0 (signalling the request completed), the result from the callback is stored in a variable for future use, otherwise the variable is set to a default value (in this case <span class="inline2">&quot;null&quot;</span>).</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_get_file.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_get_file.htm
@@ -18,6 +18,7 @@
   <p>This function connects to the specified URL in order to retrieve information in the form of a file.</p>
   <p>As this is an asynchronous function, <span data-keyref="GameMaker Name">GameMaker</span> will not block while waiting for a reply, but will keep on running unless it gets callback information. This information will be in the form of a string and will trigger an <b>Async HTTP Event</b> in any instance that has one defined in their object events.</p>
   <div data-conref="../../../../assets/snippets/Note_HTTP_Requests_CrossOrigin.hts"> </div>
+  <h2>Async Callback</h2>
   <p>This event will generate a &quot;callback&quot; which is picked up by any <a href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">HTTP Events</a>, in which case it will generate a <span data-keyref="Type_ID_DS_Map"><a href="../../Data_Structures/DS_Maps/ds_map_create.htm" target="_blank">DS Map</a></span> (more commonly known as a &quot;dictionary&quot;) that is exclusive to this event and is stored in the special variable <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span>. This DS map will contain different values depending on the data being returned, i.e.: the event will trigger multiple times as each packet of data is received so that you can show a progress bar, for example.</p>
   <div data-conref="../../../../assets/snippets/Note_HTTP_async_load_Contents.hts"> </div>
   <p> </p>
@@ -33,7 +34,7 @@
       <tr>
         <td>url</td>
         <td><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
-        <td>The web address of the server that you wish to get the file from</td>
+        <td>The web address of the server that you wish to get the file from. See <a data-xref="{text}" href="HTTP.htm#urls">URLs</a></td>
       </tr>
       <tr>
         <td>local_target</td>
@@ -46,17 +47,17 @@
   <h4>Returns:</h4>
   <p class="code"><span data-keyref="Type_ID_Async_Event"><a href="../Asynchronous_Functions.htm" target="_blank">Async Request ID</a></span> (or -1 if something went wrong)</p>
   <p> </p>
-  <h4>Extended Example:</h4>
+  <h4>Example:</h4>
   <p>The <span class="inline3_func"><span data-field="title" data-format="default">http_get_file</span></span> function can be called from any event, and since it is asynchronous the callback can be almost instantaneous or could take several seconds. Calling the function is simple and would look something like this:</p>
   <p class="code">request_id = http_get_file(&quot;http://www.macsweeneygames.com/downloads/upgrade.zip&quot;, &quot;\Downloads\Upgrade.zip&quot;);</p>
-  <p>The above code will request a file from the given URL and set it to be downloaded to the local storage area (as specified in the HTML5 Game Options), in a directory &quot;Downloads&quot; with the given file name (this does not have to be the same as the source file name, but should use the same file extension). The <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span> map index will be stored in the variable <span class="inline2">file</span> so you can check for the correct callback in the Asynchronous Event, and if the save directory does not exist, it will be created. The Asynchronous Event triggered would be the <a data-xref="{title}" href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">HTTP</a> sub-event, and in that event you would have something like the following:</p>
+  <p>The above code will request a file from the given URL and set it to be downloaded to the local storage area (as specified in the HTML5 Game Options), in a directory &quot;Downloads&quot; with the given file name (this does not have to be the same as the source file name, but should use the same file extension). The <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span> map&#39;s <span class="inline2">&quot;id&quot;</span> will be stored in the variable <span class="inline2">request_id</span> so you can check for the correct callback in the Asynchronous Event, and if the save directory does not exist, it will be created. The Asynchronous Event triggered would be the <a data-xref="{title}" href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">HTTP</a> sub-event, and in that event you would have something like the following:</p>
   <p class="code_heading">Async HTTP Event</p>
-  <p class="code">if (ds_map_find_value(async_load, &quot;id&quot;) == request_id)<br />
+  <p class="code">if (async_load[? &quot;id&quot;] == request_id)<br />
     {<br />
-        var _status = ds_map_find_value(async_load, &quot;status&quot;);<br />
+        var _status = async_load[? &quot;status&quot;];<br />
         if (_status == 0)<br />
         {<br />
-            var _path = ds_map_find_value(async_load, &quot;result&quot;);<br />
+            var _path = async_load[? &quot;result&quot;];<br />
             var _files = zip_unzip(path, &quot;/NewContent/&quot;);<br />
             if (_files &gt; 0)<br />
             {<br />
@@ -64,7 +65,7 @@
             }<br />
         }<br />
     }</p>
-  <p>The above code will first check the <span class="inline2">&quot;id&quot;</span> of the DS Map that has been created, then check the status of the callback. If the value is equal to 0 (signalling success) the result from the callback will then be used along with the <span class="inline3_func"><a data-xref="{title}" href="../../File_Handling/Encoding_And_Hashing/zip_unzip.htm">zip_unzip</a></span> function to unzip the downloaded file to the given directory. If the unzip succeeds a global variable is set to <span class="inline2">true</span>.</p>
+  <p>The above code will first check the <span class="inline2">&quot;id&quot;</span> of the request, then check the status of the request. If the value is equal to 0 (signalling completed), the result will then be used along with the <span class="inline3_func"><a data-xref="{title}" href="../../File_Handling/Encoding_And_Hashing/zip_unzip.htm">zip_unzip</a></span> function to unzip the downloaded file to the given directory. If the unzip succeeds a global variable is set to <span class="inline2">true</span>.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_post_string.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_post_string.htm
@@ -16,9 +16,10 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">http_post_string</span></h1>
-  <p>In computing, a <b>post</b> request is used when the client needs to send data to the server as part of the retrieval request, such as when uploading a file or submitting a completed form, and the same is true of this function in <span data-keyref="GameMaker Name">GameMaker</span>. In contrast to the <span class="inline3_func"><a data-xref="{title}" href="http_get.htm">http_get</a></span> request method where only a URL is sent to the server, <span class="inline3_func"><span data-field="title" data-format="default">http_post_string</span></span> also includes a string that is sent to the server and may result in the creation of a new resource on the server, the update of an existing one, or both.</p>
-  <p>It should be noted that HTTP request parameters (the bits sometimes &quot;tacked on&quot; to the end of a URL when you submit a form on a web page) are perfectly acceptable when using this function too.</p>
+  <p>This function posts a string using the HTTP POST method.</p>
+  <p>In computing, a <b>post</b> request is used when the client needs to send data to the server as part of the retrieval request, such as when uploading a file or submitting a completed form, and the same is true of this function in <span data-keyref="GameMaker Name">GameMaker</span>. In contrast to the <span class="inline3_func"><a data-xref="{title}" href="http_get.htm">http_get</a></span> request method where only a <a href="HTTP.htm#urls">URL</a> is sent to the server, <span class="inline3_func"><span data-field="title" data-format="default">http_post_string</span></span> also includes a string that is sent to the server and may result in the creation of a new resource on the server, the update of an existing one, or both.</p>
   <div data-conref="../../../../assets/snippets/Note_HTTP_Requests_CrossOrigin.hts"> </div>
+  <h2>Async Callback</h2>
   <p>This event will generate a &quot;callback&quot; which is picked up by any <a href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">HTTP Events</a>, in which case it will generate a <span data-keyref="Type_ID_DS_Map"><a href="../../Data_Structures/DS_Maps/ds_map_create.htm" target="_blank">DS Map</a></span> (more commonly known as a &quot;dictionary&quot;) that is exclusive to this event and is stored in the special variable <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span>. This DS map will contain different values depending on whether there is data being returned or not. For example, if you have requested a file, the event will trigger multiple times as each packet of data is received so that you can show a progress bar, for example.</p>
   <div data-conref="../../../../assets/snippets/Note_HTTP_async_load_Contents.hts"> </div>
   <p> </p>
@@ -34,7 +35,7 @@
       <tr>
         <td>url</td>
         <td><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
-        <td>The web address of the server that you wish to get information from</td>
+        <td>The web address of the server that you wish to get information from. See <a data-xref="{text}" href="HTTP.htm#urls">URLs</a></td>
       </tr>
       <tr>
         <td>string</td>
@@ -47,21 +48,21 @@
   <h4>Returns:</h4>
   <p class="code"><span data-keyref="Type_ID_Async_Event"><a href="../Asynchronous_Functions.htm" target="_blank">Async Request ID</a></span> (or -1 if something went wrong)</p>
   <p> </p>
-  <h4>Extended Example:</h4>
+  <h4>Example:</h4>
   <p>The <span class="inline3_func"><span data-field="title" data-format="default">http_post_string</span></span> function can be called from any event, and since it is asynchronous the callback can be almost instantaneous or could take several seconds. Calling the function is simple and would look something like this:</p>
   <p class="code">var _str = $&quot;name={player_name}&amp;score={player_score}&quot;;<br />
     request_id = <span data-field="title" data-format="default">http_post_string</span>(&quot;http://www.angusgames.com/game?game_id={global.game_id}&quot;, _str);</p>
   <p>The above code sends a retrieval request to the specified URL with the given parameters as well as sending the additional data (player name and score in URL-encoded form) stored in the variable <span class="inline2">_str</span>. This will trigger all defined asynchronous <b>Http Events</b> if a callback is received, and you can check the <span class="inline2">&quot;id&quot;</span> returned against that stored in the variable <span class="inline2">request_id</span> to make sure that you run the correct code should you have used various <span class="inline3_func"><span data-field="title" data-format="default">http_post_string</span></span> functions. The following example code shows how this would be done:</p>
   <p class="code_heading">Async HTTP Event</p>
   <p class="code">var _r_str = &quot;null&quot;;<br />
-    if (ds_map_find_value(async_load, &quot;id&quot;) == request_id)<br />
+    if (async_load[? &quot;id&quot;] == request_id)<br />
     {<br />
-        if (ds_map_find_value(async_load, &quot;status&quot;) == 0)<br />
+        if (async_load[? &quot;status&quot;] == 0)<br />
         {<br />
-            _r_str = ds_map_find_value(async_load, &quot;result&quot;);<br />
+            _r_str = async_load[? &quot;result&quot;];<br />
         }<br />
     }</p>
-  <p>The above code will first check the ID of the DS map that has been created, then check the status of the callback. If the value is equal to 0 (signalling success) the result from the callback will then be stored in a variable for future use, otherwise the variable will simply hold a default value (in this case <span class="inline2">&quot;null&quot;</span>).</p>
+  <p>The above code will first check the ID of the request, then check the status of the callback. If the value is equal to 0 (signalling completed) the result from the callback will then be stored in a variable for future use, otherwise the variable will simply hold a default value (in this case <span class="inline2">&quot;null&quot;</span>).</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_request.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_request.htm
@@ -15,21 +15,27 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">http_request</span></h1>
-  <p>This function creates an HTTP request and sends it.</p>
-  <p>An HTTP request can be used for many things like (for example) authentication via HTTP headers if you use RESTful APIs.</p>
-  <p>The function requires the full IP address of the server to request from as well as the type of request to make: <span class="inline2">&quot;GET&quot;</span>, <span class="inline2">&quot;HEAD&quot;</span>, <span class="inline2">&quot;POST&quot;</span>, <span class="inline2">&quot;PUT&quot;</span>, <span class="inline2">&quot;DELETE&quot;</span>, <span class="inline2">&quot;TRACE&quot;</span>, <span class="inline2">&quot;OPTIONS&quot;</span> or <span class="inline2">&quot;CONNECT&quot;</span>. You&#39;ll also need to supply a <span data-keyref="Type_ID_DS_Map"><a href="../../Data_Structures/DS_Maps/ds_map_create.htm" target="_blank">DS Map</a></span> of key/value pairs (as strings, where the key is the header field and the value is the required data for the header). The final argument is an optional data string that you can add to the request, and if it&#39;s not needed then it can be either 0 or an empty string <span class="inline2">&quot;&quot;</span>. Note that you can also send a buffer (see the section on <a data-xref="{title}" href="../../Buffers/Buffers.htm">Buffers</a> for more details), in which case the last argument would be the handle to the buffer to send.</p>
+  <p>This function creates a generic HTTP request and sends it.</p>
+  <p>A HTTP request can be used for many things like (for example) authentication via HTTP headers if you use RESTful APIs.</p>
+  <p>The function requires:</p>
+  <ul class="colour">
+    <li>The URL to request. See <a data-xref="{text}" href="HTTP.htm#urls">URLs</a></li>
+    <li>The request method: <span class="inline2">&quot;GET&quot;</span>, <span class="inline2">&quot;HEAD&quot;</span>, <span class="inline2">&quot;POST&quot;</span>, <span class="inline2">&quot;PUT&quot;</span>, <span class="inline2">&quot;DELETE&quot;</span>, <span class="inline2">&quot;TRACE&quot;</span>, <span class="inline2">&quot;OPTIONS&quot;</span> or <span class="inline2">&quot;CONNECT&quot;</span>.</li>
+    <li>A <span data-keyref="Type_ID_DS_Map"><a href="../../Data_Structures/DS_Maps/ds_map_create.htm" target="_blank">DS Map</a></span> of key/value pairs containing the HTTP headers <span class="inline2">&quot;key:value&quot;</span> (as strings, where the key is the header field and the value is the required data for the header). Note that key and value strings shouldn&#39;t include the colon <span class="inline2">&quot;:&quot;</span>.</li>
+    <li>An optional request body, which can be:
+      <ul>
+        <li>A data <span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span> (can be an empty string <span class="inline2">&quot;&quot;</span> for an empty body)</li>
+        <li>A <span data-keyref="Type_ID_Buffer"><a href="../../Buffers/buffer_create.htm" target="_blank">Buffer</a></span> (for binary data). If the seek position is at the start (0), no body is sent and the buffer is filled with the response from the HTTP call. If the seek position is non-zero, the entire buffer contents (up to <span class="inline3_func"><a data-xref="{title}" href="../../Buffers/buffer_set_used_size.htm">buffer_set_used_size</a></span>) are sent as the body.</li>
+      </ul>
+    </li>
+  </ul>
   <p>The function returns an <span data-keyref="Type_ID_Async_Event"><a href="../Asynchronous_Functions.htm" target="_blank">Async Request ID</a></span> which can be used to identify its callback, as described below.</p>
   <div data-conref="../../../../assets/snippets/Note_HTTP_Requests_CrossOrigin.hts"> </div>
-  <h3>Usage Notes</h3>
-  <ul class="colour">
-    <li>HTTP headers normally follow the format &quot;key:value&quot;, but since <span data-keyref="GameMaker Name">GameMaker</span> creates these pairs for you from the DS map there is no need to include the colon &quot;:&quot; in your map key or value strings.</li>
-    <li>When using a buffer for the body argument, if the buffer seek position is at the start (0) then no body is sent and the buffer is filled with the response from the HTTP call, but if the buffer seek position is non-zero, then the buffer string content is sent as the body.</li>
-  </ul>
   <h2>Async Callback</h2>
-  <p>This event will generate a &quot;callback&quot; which is picked up by any <a href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">Async HTTP Events</a>, in which case it will generate a <span data-keyref="Type_ID_DS_Map"><a href="../../Data_Structures/DS_Maps/ds_map_create.htm" target="_blank">DS Map</a></span> that is exclusive to this event and is stored in the special variable <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span>. This DS map has the following two keys related to the request function:</p>
+  <p>This function will generate &quot;callbacks&quot; which are picked up by any <a href="../../../../The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm">Async HTTP Events</a>, in which case it will generate a <span data-keyref="Type_ID_DS_Map"><a href="../../Data_Structures/DS_Maps/ds_map_create.htm" target="_blank">DS Map</a></span> that is exclusive to this event and is stored in the special variable <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span>. This DS map has the following two keys related to the request function:</p>
   <ul class="colour">
-    <li><b>id: </b>The ID which was returned from the function. If you fire off a series of <span class="inline2">http_*</span> requests then you need to know which one you are getting the reply to, and so you would use this value to compare to the value you stored when you originally sent the request to find the right one.</li>
-    <li><b>response_headers:</b> If this has a value greater than or equal to 0, it holds a DS map that contains the HTTP headers returned with the response to the HTTP request.</li>
+    <li><b>&quot;id&quot;: </b>The ID which was returned from the function. If you fire off a series of <span class="inline2">http_*</span> requests then you need to know which one you are getting the reply to, and so you would use this value to compare to the value you stored when you originally sent the request to find the right one.</li>
+    <li><b>&quot;response_headers&quot;:</b> If this has a value greater than or equal to 0, it holds a DS map that contains the HTTP headers returned with the response to the HTTP request.</li>
   </ul>
   <p> </p>
   <h4>Syntax:</h4>
@@ -44,7 +50,7 @@
       <tr>
         <td>url</td>
         <td><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
-        <td>The web address of the server that you wish to get information from</td>
+        <td>The web address of the server that you wish to get information from. See <a data-xref="{text}" href="HTTP.htm#h"> </a></td>
       </tr>
       <tr>
         <td>method</td>
@@ -58,8 +64,8 @@
       </tr>
       <tr>
         <td>body</td>
-        <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span>, <span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span>, or <span data-keyref="Type_ID_Buffer"><a href="../../Buffers/buffer_create.htm" target="_blank">Buffer</a></span></td>
-        <td>The data to be transmitted following the headers (can be a binary buffer handle)</td>
+        <td><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span> or <span data-keyref="Type_ID_Buffer"><a href="../../Buffers/buffer_create.htm" target="_blank">Buffer</a></span></td>
+        <td>The data to be transmitted in the body, following the headers (can be a binary buffer handle).</td>
       </tr>
     </tbody>
   </table>
@@ -75,7 +81,7 @@
     var _data=&quot;utf8=%E2%9C%93&amp;authenticity_token=kPmS14DcYcuKgMFZUsN3XFfj3mhs%3D&amp;product%5Bname%5D=CatchTheHaggis&amp;product%5Bproduct_id%5D=http_test&amp;commit=Create+Product&quot;;<br />
     request_id = <span data-field="title" data-format="default">http_request</span>(&quot;http://225.0.0.97:3000/products&quot;, &quot;POST&quot;, _headers, _data);<br />
     ds_map_destroy(_headers);</p>
-  <p>The above code creates a DS map with the relevant HTTP headers for the function, then creates a data string for use as this is a POST request. Finally the function is called, with its ID value being stored in the instance variable <span class="inline2">request_id</span> for checking in the HTTP asynchronous event.</p>
+  <p>The above code creates a DS map with the relevant HTTP headers for the request, then creates a data string for use as this is a POST request. Finally, the function is called, with its ID value being stored in the instance variable <span class="inline2">request_id</span> for checking in the HTTP asynchronous event.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_restart.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_restart.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>game_restart</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../assets/css/default.css" type="text/css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,19 +15,19 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">game_restart</span></h1>
-  <p>With this function you can restart the game. This is essentially the same as running the game for the first time and so the <a href="../../../The_Asset_Editors/Object_Properties/Other_Events.htm">Game Start Event</a> will be triggered, <i>as well as</i> the <a href="../../../The_Asset_Editors/Object_Properties/Other_Events.htm">Game End Event</a>.</p>
+  <p>This function restarts the game.</p>
+  <p>Restarting the game is essentially the same as running it for the first time and so the <a href="../../../The_Asset_Editors/Object_Properties/Other_Events.htm">Game Start Event</a> will be triggered <i>as well as</i> the <a href="../../../The_Asset_Editors/Object_Properties/Other_Events.htm">Game End Event</a>.</p>
+  <p><span>All time sources created by <span class="inline3_func"><a data-xref="{title}" href="../Time_Sources/call_later.htm">call_later</a></span> are destroyed upon restarting the game.</span></p>
   <div data-conref="../../../assets/snippets/changing_room_stops_instance_creation.hts"> </div>
   <p>It should be noted that certain things will <b>not</b> be reset when this function is called:</p>
   <ul class="colour">
-    <li>Global variables will not be re-initialised unless explicitly coded as such - for example, the built-in global variable <span class="inline">score</span> will not start at zero after a game restart if it has been modified in the game already.</li>
-    <li>The GPU state will not be changed (so if you have set the draw colour or alpha, for example, it will remain at the changed value).</li>
-    <li>The game speed will remain at whatever you set it in your game code (if you changed it this change will be perpetuated).</li>
-    <li>Any asset from the Asset Browser that has been changed at run time within the game - for example if you change the origin for a sprite resource or shift the position of a path resource - will <i>not</i> be reset.</li>
-    <li>Dynamic resources like buffers, surfaces, data-structures or imported sprites will also not be cleaned up or removed (although you may lose references to them, so take care when using this function to either use global references for the dynamic resource, or to clean them up before the function is called).</li>
-    <br />
-    <br />
-     
+    <li><a data-xref="{title}" href="../../GML_Overview/Variables/Global_Variables.htm">Global Variables</a> will not be re-initialised unless explicitly coded as such - for example, the built-in global variable <span class="inline2"><a data-xref="{title}" href="../../GML_Overview/Variables/Builtin_Global_Variables/score.htm">score</a></span> will not start at zero after a game restart if it has been modified in the game already.</li>
+    <li>The <a href="../Drawing/GPU_Control/gpu_get_state.htm" title="gpu_get_state()">GPU state</a> will not be changed (so if you have set the draw colour or alpha, for example, it will remain at the changed value).</li>
+    <li>The <a href="game_get_speed.htm" title="game_get_speed()">game speed</a> will remain at whatever you set it in your game code (if you changed it this change will be perpetuated).</li>
+    <li>Any asset from the Asset Browser that has been changed at run time within the game - for example if you change the origin of a sprite asset or shift the position of a path asset - will <i>not</i> be reset.</li>
+    <li>Dynamic resources like buffers, surfaces, data structures or imported sprites will also not be cleaned up or removed (although you may lose references to them, so take care when using this function to either use global references for the dynamic resource, or to clean them up before the function is called).</li>
   </ul>
+  <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">game_restart</span>();</p>
   <p> </p>
@@ -35,18 +35,21 @@
   <p class="code"><span data-keyref="Type_Void">N/A</span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code">if keyboard_check_pressed(ord(&quot;R&quot;)) <span data-field="title" data-format="default">game_restart</span>();</p>
-  <p>This would restart the game when the player presses the &quot;R&quot; key.</p>
+  <p class="code">if keyboard_check_pressed(ord(&quot;R&quot;))<br />
+    {<br />
+        <span data-field="title" data-format="default">game_restart</span>();<br />
+    }</p>
+  <p>This code restarts the game when the player presses the &quot;R&quot; key.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="General_Game_Control.htm">General Game Control</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="General_Game_Control.htm">General Game Control</a></div>
         <div style="float:right">Next: <a data-xref="{title}" href="game_change.htm">game_change</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 game_restart

--- a/Manual/contents/The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm
+++ b/Manual/contents/The_Asset_Editors/Object_Properties/Async_Events/HTTP.htm
@@ -15,28 +15,16 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">HTTP</span></h1>
-  <p><img alt="HTTP Event" class="center" src="../../../assets/Images/Asset_Editors/Async_HTTP.png" />The HTTP Event is one that is triggered by the <a class="glossterm" data-glossterm="callback" href="#">callback</a> from one of the <a href="../../../GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/HTTP.htm"><span class="inline">http_*()</span> functions</a>, like <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_post_string.htm">http_post_string</a></span>. It actually generates a <a href="../../../GameMaker_Language/GML_Reference/Data_Structures/DS_Maps/DS_Maps.htm">DS Map</a> that is exclusive to this event and is stored in the special variable <span class="inline2"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span> (please see the individual functions for code examples that explain the use of this event in further detail). This DS map has the following general structure:</p>
-  <ul class="dropspotlist">
-    <li class="dropspot">&quot;<span class="inline">id</span>&quot;: The ID which was returned from the command. If you fire off a series of <span class="inline2">http_*</span> requests then you need to know which one you are getting the reply to, and so you would use this value to compare to the value you stored when you originally sent the request to find the right one.</li>
-    <li class="dropspot">&quot;<span class="inline">status</span>&quot;: Holds a value of less than 0 for an error, 0 for success and 1 if content is being downloaded.</li>
-    <li class="dropspot">&quot;<span class="inline">result</span>&quot;: The data received (string only), or the path to the file downloaded if you have used <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_get_file.htm">http_get_file</a></span>. You may only get this key if the status is 0, but that is platform-dependent.</li>
-    <li class="dropspot">&quot;<span class="inline">url</span>&quot;: The complete URL you requested.</li>
-    <li class="dropspot">&quot;<span class="inline">http_status</span>&quot;: The raw HTTP status code (if available). This returns the standard web status code for most browsers, e.g.: 304 for &quot;Not Modified&quot;, 204 for &quot;No Content&quot;, etc.</li>
-  </ul>
-  <p>The above shows what you get when you use the <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_post_string.htm">http_post_string</a></span> function, but each of the <span class="inline2">http_*</span> functions may return a slightly different map, so please refer to the manual entry for each function to find out the precise data that is returned for it.</p>
-  <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> As <span class="inline2"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span> creates a DS map, these functions are particularly useful when coupled with the <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/File_Handling/Encoding_And_Hashing/json_encode.htm">json_encode</a></span> and <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/File_Handling/Encoding_And_Hashing/json_decode.htm">json_decode</a></span> functions.</p>
-  <p>There could also be additional data supplied by this map if you have requested files for downloading. In this case, the <span class="inline2">&quot;status&quot;</span> will have a value of 1 and the DS map will hold these extra keys:</p>
-  <ul class="dropspotlist">
-    <li class="dropspot">&quot;<span class="inline">contentLength</span>&quot;: This is the size of file that the web server has said you should expect to receive (may be -1 if the server does not return this data).</li>
-    <li class="dropspot">&quot;<span class="inline">sizeDownloaded</span>&quot;: The size of the data that has already been downloaded.</li>
-  </ul>
-  <p>Note that the event will not be triggered for every single data packet that is received, but will rather update at any time during the download within the main game loop. Also note that currently this functionality is only available for regular Windows target platforms.</p>
+  <h3> </h3>
+  <p><img alt="HTTP Event" class="center" height="322" src="../../../assets/Images/Asset_Editors/Async_HTTP.png" width="344" />The Async <span data-field="title" data-format="default">HTTP</span> Event is triggered by the <a class="glossterm" data-glossterm="callback" href="#">callback</a> from one of the <a href="../../../GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/HTTP.htm"><span class="inline">http_*()</span> functions</a>, like <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_post_string.htm">http_post_string</a></span>. It isn&#39;t triggered for every single data packet that is received, but rather updates within the main game loop during the download.</p>
+  <p>A <a href="../../../GameMaker_Language/GML_Reference/Data_Structures/DS_Maps/DS_Maps.htm">DS Map</a> that is exclusive to this event and is stored in the special variable <span class="inline2"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span> can be accessed in this event (please see the individual functions for code examples that explain the use of this event in further detail).</p>
+  <div data-conref="../../../assets/snippets/Note_HTTP_async_load_Contents.hts"> </div>
   <p> </p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="../Async_Events.htm">Async Events</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="../Async_Events.htm">Async Events</a></div>
         <div style="float:right">Next: <a href="IAP.htm">In-App Purchase</a></div>
       </div>
     </div>

--- a/Manual/contents/assets/snippets/Note_HTTP_async_load_Contents.hts
+++ b/Manual/contents/assets/snippets/Note_HTTP_async_load_Contents.hts
@@ -11,16 +11,17 @@
 <body>
   <p>The general structure for the DS map will be as follows:</p>
   <ul class="colour">
-    <li><b>id: </b>The ID which was returned from the command. If you fire off a series of <span class="inline2">http_*</span> requests then you need to know which one you&#39;re getting the reply to, and so you would use this value to compare to the value you stored when you originally sent the request to find the right one.</li>
-    <li><b>status: </b>Holds a value of less than 0 for an error, 0 for complete and 1 for receiving packets (see below for more details).</li>
-    <li><b>result: </b>The data received (string only).</li>
-    <li><b>url: </b>The complete URL you requested.</li>
-    <li><b>http_status: </b>The raw HTTP status code (if available). This returns the standard web status code for most browsers, e.g.: 304 for &quot;Not Modified&quot;, 204 for &quot;No Content&quot;, etc.</li>
+    <li><b>&quot;id&quot;: </b>The ID which was returned from the command. If you fire off a series of <span class="inline2">http_*</span> requests then you need to know which one you&#39;re getting the reply to, and so you would use this value to compare to the value you stored when you originally sent the request to find the right one.</li>
+    <li><b>&quot;status&quot;: </b>Holds a value of less than 0 for an error, 0 for complete and 1 for receiving packets (see below for more details).</li>
+    <li><b>&quot;result&quot;: </b>The data received (string only), the path to the file downloaded if you have used <span class="inline3_func"><a data-xref="{title}" href="../../GameMaker_Language/GML_Reference/Asynchronous_Functions/HTTP/http_get_file.htm">http_get_file</a></span> or the number of bytes written to the buffer using a buffer with the seek position at 0. You may only get this key if the status is 0, but that is platform-dependent.</li>
+    <li><b>&quot;url&quot;: </b>The complete URL you requested.</li>
+    <li><b>&quot;http_status&quot;: </b>The raw HTTP status code (if available). This returns the standard web status code for most browsers, e.g.: 304 for &quot;Not Modified&quot;, 204 for &quot;No Content&quot;, etc.</li>
   </ul>
-  <p>If multiple packets are returned to your game, the callback <span class="inline2">&quot;status&quot;</span> key will return 1, in which case the DS map will have the following additional keys:</p>
+  <p>If multiple packets are returned to your game, the callback <span class="inline2">&quot;status&quot;</span> key will hold the value 1 and the DS map will have the following additional keys:</p>
   <ul class="colour">
     <li><b>&quot;contentLength&quot;: </b>This is the size of file that the web server has said you should expect to receive (may be -1 if the server does not return this data).</li>
     <li><b>&quot;sizeDownloaded&quot;: </b>The size of the data that has already been downloaded.</li>
   </ul>
+  <p class="note"><span data-conref="Tag_note.hts"> </span> Currently this functionality is only available for regular Windows target platforms.</p>
 </body>
 </html>


### PR DESCRIPTION
This PR has changes for the following tickets: 

* https://github.com/YoYoGames/GameMaker-Manual/issues/154
* https://github.com/YoYoGames/GameMaker-Bugs/issues/7403