### PR TITLE
Further syntax highlighting improvements

### DIFF
--- a/Manual/contents/assets/scripts/gml.js
+++ b/Manual/contents/assets/scripts/gml.js
@@ -439,6 +439,7 @@ export default function(hljs) {
     "iap_storeload_failed",
     "iap_storeload_ok",
     "iap_unavailable",
+    "infinity",
     "input_type",
     "kbv_autocapitalize_characters",
     "kbv_autocapitalize_none",

--- a/Manual/contents/assets/scripts/gml.js
+++ b/Manual/contents/assets/scripts/gml.js
@@ -1041,6 +1041,7 @@ export default function(hljs) {
       }
     ]
   };
+  
   /**
    * Various representations of numbers
    */
@@ -1054,6 +1055,7 @@ export default function(hljs) {
       { match: /\b[0-9][0-9_.]*/ }
     ]
   };
+
   /**
    * Pre-processor modes for macro definitions and regions.
    */
@@ -1094,10 +1096,12 @@ export default function(hljs) {
       },
     ]
   };
+
   /**
    * A single-line comment.
    */
   const COMMENT_LINE = hljs.COMMENT('//', /\$|\n/);
+
   /**
    * Modes for the types of comments supported in GML.
    */
@@ -1107,6 +1111,7 @@ export default function(hljs) {
       hljs.C_BLOCK_COMMENT_MODE,
     ]
   };
+
   /**
    * Dot accessor usage with a special highlighting case for `global`.
    */
@@ -1142,6 +1147,7 @@ export default function(hljs) {
       }
     },
   ];
+
   /**
    * Function call sites, just looking for `<ident>(`. This creates false positives
    * for keywords such as `if (<condition>)`, so has lower priority in the mode `contains` list.
@@ -1156,6 +1162,7 @@ export default function(hljs) {
       1: "function"
     }
   };
+
   /**
    * The manual likes using `obj_` and such to define assets. Sneaky trick to make it look nicer :P
    */
@@ -1167,6 +1174,7 @@ export default function(hljs) {
       { begin: "obj_" },
     ]
   };
+
   /**
    * Expressions, which form part of a valid statement.
    */
@@ -1191,6 +1199,7 @@ export default function(hljs) {
     },
     contains: EXPRESSION
   };
+  
   /**
    * A struct variable declaration, of `<ident>:`
    */
@@ -1204,6 +1213,7 @@ export default function(hljs) {
       2: "variable-instance"
     },
   };
+
   /**
    * A function declaration matching for:
    * ```gml
@@ -1222,6 +1232,7 @@ export default function(hljs) {
       3: "function"
     }
   };
+
   /**
    * An enum definition in the form:
    * ```gml
@@ -1261,6 +1272,7 @@ export default function(hljs) {
       }
     ]
   };
+
   return {
     name: 'GML',
     case_insensitive: false, // language is case-sensitive

--- a/Manual/contents/assets/scripts/gml.js
+++ b/Manual/contents/assets/scripts/gml.js
@@ -964,11 +964,37 @@ export default function(hljs) {
    * supported in the engine.)
    */
   const DOT_ACCESSOR_REG = /\b\.\b/;
+
+  /**
+   * A template string substitution. `contains` is filled in after `EXPRESSION` is defined due to
+   * nesting.
+   */
+  const STRING_SUBSTITUTION = {
+    begin: /{/,
+    end: /}/,
+    // contains: EXPRESSION
+  };
+
   /**
    * Various types of strings supported in the engine.
    */
   const STRING = {
     variants: [
+      {
+        begin: /\$"/,
+        end: "\"",
+        beginScope: "string",
+        endScope: "string",
+        illegal: '\\n',
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          STRING_SUBSTITUTION,
+          {
+            match: /[^\n"{}]/,
+            scope: "string"
+          }
+        ]
+      },
       hljs.QUOTE_STRING_MODE,
       {
         scope: "string",
@@ -1118,6 +1144,9 @@ export default function(hljs) {
     FUNCTION_CALL,
     USER_ASSET_CONSTANT
   ];
+
+  STRING_SUBSTITUTION.contains = EXPRESSION;
+
   const SWITCH_CASE = {
     begin: [
       /case/,

--- a/Manual/contents/assets/scripts/gml.js
+++ b/Manual/contents/assets/scripts/gml.js
@@ -978,6 +978,15 @@ export default function(hljs) {
   };
 
   /**
+   * A template string substitution for use with the older `string()` optional args with `"{0}"`,
+   * etc.
+   */
+  const STRING_NUMERICAL_SUBSTITUTION = {
+    match: /{[0-9]+}/,
+    scope: "literal"
+  };
+
+  /**
    * An escape sequence in a string.
    */
   const STRING_ESCAPE = {
@@ -1010,19 +1019,24 @@ export default function(hljs) {
       {
         scope: "string",
         begin: "@'",
-        end: "'"
+        end: "'",
+        contains: [STRING_NUMERICAL_SUBSTITUTION]
       },
       {
         scope: "string",
         begin: "@\"",
-        end: "\""
+        end: "\"",
+        contains: [STRING_NUMERICAL_SUBSTITUTION]
       },
       {
         scope: "string",
         begin: /"/,
         end: /"/,
         illegal: "\\n",
-        contains: [STRING_ESCAPE]
+        contains: [
+          STRING_ESCAPE, 
+          STRING_NUMERICAL_SUBSTITUTION
+        ]
       }
     ]
   };

--- a/Manual/contents/assets/scripts/gml.js
+++ b/Manual/contents/assets/scripts/gml.js
@@ -967,6 +967,11 @@ export default function(hljs) {
   const DOT_ACCESSOR_REG = /\b\.\b/;
 
   /**
+   * Expressions, which form part of a valid statement.
+   */
+  const EXPRESSION = [];
+
+  /**
    * A template string substitution. `contains` is filled in after `EXPRESSION` is defined due to
    * nesting.
    */
@@ -975,7 +980,7 @@ export default function(hljs) {
     end: /}/,
     beginScope: "literal",
     endScope: "literal",
-    // contains: EXPRESSION
+    contains: EXPRESSION
   };
 
   /**
@@ -1041,7 +1046,7 @@ export default function(hljs) {
       }
     ]
   };
-  
+
   /**
    * Various representations of numbers
    */
@@ -1176,17 +1181,14 @@ export default function(hljs) {
   };
 
   /**
-   * Expressions, which form part of a valid statement.
+   * A ternary expression, matching partial ternary as `? <EXPRESSION> :`.
+   * Effectively exists to prevent {@link STRUCT_LITERAL_MEMBER} from stealing `<EXPRESSION> :`.
    */
-  const EXPRESSION = [
-    STRING,
-    PROP_ACCESS,
-    NUMBER,
-    FUNCTION_CALL,
-    USER_ASSET_CONSTANT
-  ];
-
-  STRING_SUBSTITUTION.contains = EXPRESSION;
+  const TERNARY = {
+    begin: /\?/,
+    end: /:/,
+    contains: EXPRESSION
+  };
 
   const SWITCH_CASE = {
     begin: [
@@ -1273,6 +1275,15 @@ export default function(hljs) {
     ]
   };
 
+  EXPRESSION.push(
+    STRING,
+    TERNARY,
+    PROP_ACCESS,
+    NUMBER,
+    FUNCTION_CALL,
+    USER_ASSET_CONSTANT
+  );
+
   return {
     name: 'GML',
     case_insensitive: false, // language is case-sensitive
@@ -1292,6 +1303,7 @@ export default function(hljs) {
         // Prevent keywords being taken by function calls.
         beginKeywords: KEYWORDS.join(" ")
       },
+      TERNARY,
       STRUCT_LITERAL_MEMBER,
       FUNCTION_DECLARATION,
       FUNCTION_CALL,

--- a/Manual/contents/assets/scripts/gml.js
+++ b/Manual/contents/assets/scripts/gml.js
@@ -972,7 +972,20 @@ export default function(hljs) {
   const STRING_SUBSTITUTION = {
     begin: /{/,
     end: /}/,
+    beginScope: "literal",
+    endScope: "literal",
     // contains: EXPRESSION
+  };
+
+  /**
+   * An escape sequence in a string.
+   */
+  const STRING_ESCAPE = {
+    scope: "literal",
+    variants: [
+      { match: /\\u[a-fA-F0-9]{1,6}/ },
+      { match: /\\[^\n]/ }
+    ]
   };
 
   /**
@@ -985,17 +998,15 @@ export default function(hljs) {
         end: "\"",
         beginScope: "string",
         endScope: "string",
-        illegal: '\\n',
         contains: [
-          hljs.BACKSLASH_ESCAPE,
+          STRING_ESCAPE,
           STRING_SUBSTITUTION,
           {
-            match: /[^\n"{}]/,
+            match: /[^\n"{]/,
             scope: "string"
           }
         ]
       },
-      hljs.QUOTE_STRING_MODE,
       {
         scope: "string",
         begin: "@'",
@@ -1005,6 +1016,13 @@ export default function(hljs) {
         scope: "string",
         begin: "@\"",
         end: "\""
+      },
+      {
+        scope: "string",
+        begin: /"/,
+        end: /"/,
+        illegal: "\\n",
+        contains: [STRING_ESCAPE]
       }
     ]
   };


### PR DESCRIPTION
## Brief
I worked on this quite a while back with the original set of changes, but didn't ever get around to PRing it as it wasn't quite perfect. I've decided to come back to it regardless though and PR what I've got rather than trying to get in everything.

## The notable changes include:

### Fixed conflict between ternaries and struct literal members
#### Before
![image](https://github.com/user-attachments/assets/4020f2fd-c298-4fc2-93ce-42f7737db8bb)
#### After
![image](https://github.com/user-attachments/assets/e3ea3dcc-80d4-42bf-851b-89f53b133327)

### Template strings
#### Before
![image](https://github.com/user-attachments/assets/06798e5e-ce32-4175-a53d-5d09de2f1e13)
![image](https://github.com/user-attachments/assets/0bdcc65b-19e1-4e5b-a4f8-2e015f1ad757)

#### After
![image](https://github.com/user-attachments/assets/62f7c2a2-d819-40c1-b309-06ba2e1c962f)
![image](https://github.com/user-attachments/assets/e38b0842-5c24-4076-88f8-751d72b100b4)

### String `\` escapes including unicode
#### Before
![image](https://github.com/user-attachments/assets/0c7e11a3-d792-45ea-a392-97aedd0e0aa2)
![image](https://github.com/user-attachments/assets/43446abf-4eb2-4932-a6ae-9eced8e74e46)

#### After
![image](https://github.com/user-attachments/assets/17e0f5f9-7496-4dd5-b0c0-9800d82f100b)
![image](https://github.com/user-attachments/assets/7f2e4897-7f52-41c9-887a-f8a15c177f58)

### Added the missing `infinity` constant
#### Before
![image](https://github.com/user-attachments/assets/de3f407c-7512-4137-9a22-fadd0017dcf3)

#### After
![image](https://github.com/user-attachments/assets/adb95477-e229-49c6-811c-40fa95a1e94c)
