### PR TITLE
feat: lenient leading & trailing newlines in code blocks

### DIFF
--- a/Manual/contents/assets/scripts/main_script.js
+++ b/Manual/contents/assets/scripts/main_script.js
@@ -2279,6 +2279,7 @@ var hljs = (function () {
     
         // Replace <br [/]> with line breaks to make the parser's job easier.
         node.innerHTML = node.innerHTML
+          .trim()
           .replaceAll(/\n(<br *\/*>)/g, '\n')
           .replaceAll(/(<br *\/*>)\n/g, '\n')
           .replaceAll(/(<br *\/*>)/g, '\n');


### PR DESCRIPTION
Currently, for a code block to be rendered correctly, you need to ensure that there is no leading and trailing whitespace. For instance, the following code:

```gml
if (condition) {
    fn();
}
```

Must be written like so:

```html
<p class="code">if (condition) {
    fn();
}</p>
```

This is presumably the default behaviour of RoboHelp, but adds another - if _extremely_ small - barrier to contributions from the community, who are more likely than not editing the HTML directly.

To fix this, I've just changed the parser to implicitly trim leading and trailing whitespace from code block contents. I'm not aware of any case where the current behaviour (the leading and trailing whitespace being visible in the output) would actually be wanted, but on the off chance that this is desired, a `<br>` tag can be used to force a line break to occur regardless, since the trimming is done before line breaks and `<br>` tags are normalized to `\n`.

The result of the change is that the sample code block can now be expressed as follows, and displays as intended:

```html
<p class="code">
    if (condition) {
        fn();
    }
</p>
```

> [!NOTE]
> In the given examples I've ignored the issue where non-breaking space characters are required to indent correctly, as that isn't related to this. On that though, I could also have a look at removing leading indentation in code blocks too - this would make it valid to use regular space characters for code blocks, at which point the CSS `white-space: pre` style could be used.