### PR TITLE
fix: import highlighting on all pages using code blocks

### DIFF
--- a/Manual/contents/Additional_Information/Guide_To_Using_JSON.htm
+++ b/Manual/contents/Additional_Information/Guide_To_Using_JSON.htm
@@ -7,6 +7,7 @@
   <title>Guide To Using JSON</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../assets/css/default.css" />
+  <script src="../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Bart Teunis" />
   <meta name="topic-comment" content="This page is a guide on how to work with JSON in GameMaker" />
   <meta name="template" content="../assets/masterpages/Manual_Page.htt" />

--- a/Manual/contents/GameMaker_Language/GML_Overview/Values_And_References.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Values_And_References.htm
@@ -7,6 +7,7 @@
   <title>Values and References</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../assets/css/default.css" />
+  <script src="../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Bart Teunis" />
   <meta name="topic-comment" content="A page describing the difference between values and references, pass by value vs pass by reference as well as related subjects." />
   <meta name="template" content="../../assets/masterpages/Manual_Page.htt" />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Loop_Points/Audio_Loop_Points.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Loop_Points/Audio_Loop_Points.htm
@@ -7,6 +7,7 @@
   <title>Audio Loop Points</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../../../assets/css/default.css" />
+  <script src="../../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Bart Teunis" />
   <meta name="topic-comment" content="Reference page for the audio loop points feature" />
   <meta name="template" content="../../../../../assets/masterpages/Manual_Page.htt" />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Properties.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Properties.htm
@@ -7,6 +7,7 @@
   <title>Audio Properties Overview</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../../assets/css/default.css" />
+  <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Bart Teunis" />
   <meta name="topic-comment" content="A page to provide a quick overview on all the audio properties and the levels at which they can be set" />
   <meta name="template" content="../../../../assets/masterpages/Manual_Page.htt" />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Filter_Effect_Layers/fx_set_single_layer.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Filter_Effect_Layers/fx_set_single_layer.htm
@@ -7,6 +7,7 @@
   <title>fx_set_single_layer</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../../../assets/css/default.css" />
+  <script src="../../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="template" content="../../../../../assets/masterpages/Manual_Keyword_Page.htt" />
   <meta name="rh-authors" content="Gurpreet S. Matharoo" />
   <meta name="rh-index-keywords" content="fx_set_single_layer" />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/The_Debug_Overlay.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/The_Debug_Overlay.htm
@@ -7,6 +7,7 @@
   <title>The Debug Overlay</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../assets/css/default.css" />
+  <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Bart Teunis" />
   <meta name="topic-comment" content="Reference page for the debug overlay" />
   <meta name="template" content="../../../assets/masterpages/Manual_Page.htt" />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Depth_And_Stencil_Buffer/The_Depth_And_Stencil_Buffer.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Depth_And_Stencil_Buffer/The_Depth_And_Stencil_Buffer.htm
@@ -7,6 +7,7 @@
   <title>The Depth And Stencil Buffer</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../../assets/css/default.css" />
+  <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Bart Teunis" />
   <meta name="topic-comment" content="Overview page for the depth and stencil buffer" />
   <meta name="template" content="../../../../assets/masterpages/Manual_Page.htt" />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Videos/video_draw.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Videos/video_draw.htm
@@ -7,6 +7,7 @@
   <title>video_draw</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../../assets/css/default.css" />
+  <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="template" content="../../../../assets/masterpages/Manual_Keyword_Page.htt" />
   <meta name="rh-authors" content="Gurpreet S. Matharoo" />
   <meta name="topic-comment" content="Reference page for video_draw" />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Videos/video_open.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Videos/video_open.htm
@@ -7,6 +7,7 @@
   <title>video_open</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../../assets/css/default.css" />
+  <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="template" content="../../../../assets/masterpages/Manual_Keyword_Page.htt" />
   <meta name="rh-authors" content="Gurpreet S. Matharoo" />
   <meta name="topic-comment" content="Reference page for video_open" />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Videos/video_set_volume.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Videos/video_set_volume.htm
@@ -7,6 +7,7 @@
   <title>video_set_volume</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../../assets/css/default.css" />
+  <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="template" content="../../../../assets/masterpages/Manual_Keyword_Page.htt" />
   <meta name="rh-authors" content="Gurpreet S. Matharoo" />
   <meta name="topic-comment" content="Reference page for video_set_volume" />

--- a/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/Encoding_And_Hashing/json_decode.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/Encoding_And_Hashing/json_decode.htm
@@ -7,6 +7,7 @@
   <title>json_decode</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../../assets/css/default.css" />
+  <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="template" content="../../../../assets/masterpages/Manual_Page.htt" />
   <meta name="search-keywords" content="json_decode,json" />
   <meta name="rh-index-keywords" content="json_decode" />

--- a/Manual/contents/The_Asset_Editors/Code_Editor_Properties/Feather_Directives.htm
+++ b/Manual/contents/The_Asset_Editors/Code_Editor_Properties/Feather_Directives.htm
@@ -7,6 +7,7 @@
   <title>Feather Directives</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../assets/css/default.css" />
+  <script src="../../assets/scripts/main_script.js" type="module"></script>
   <meta name="template" content="../../assets/masterpages/Manual_Page.htt" />
   <meta name="rh-authors" content="Bart Teunis" />
   <meta name="topic-comment" content="Reference page listing all Feather directives" />

--- a/Manual/contents/The_Asset_Editors/Object_Properties/Async_Events/Audio_Playback_Ended.htm
+++ b/Manual/contents/The_Asset_Editors/Object_Properties/Async_Events/Audio_Playback_Ended.htm
@@ -7,6 +7,7 @@
   <title>Audio Playback Ended</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../assets/css/default.css" />
+  <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Bart Teunis" />
   <meta name="topic-comment" content="Reference page for the async Audio Playback Ended event" />
   <meta name="template" content="../../../assets/masterpages/Manual_Page.htt" />

--- a/Manual/contents/The_Asset_Editors/Object_Properties/Wallpaper_Config_Event.htm
+++ b/Manual/contents/The_Asset_Editors/Object_Properties/Wallpaper_Config_Event.htm
@@ -7,6 +7,7 @@
   <title>Wallpaper Events</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../assets/css/default.css" />
+  <script src="../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Bart Teunis" />
   <meta name="topic-comment" content="Reference page for the Wallpaper Config event, used with Live Wallpapers" />
   <meta name="template" content="../../assets/masterpages/Manual_Page.htt" />

--- a/Manual/contents/The_Asset_Editors/Particle_Systems.htm
+++ b/Manual/contents/The_Asset_Editors/Particle_Systems.htm
@@ -7,6 +7,7 @@
   <title>The Particle System Editor</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../assets/css/default.css" />
+  <script src="../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Gurpreet S. Matharoo, Bart Teunis" />
   <meta name="topic-comment" content="Documentation page for the Particle System Editor" />
   <meta name="template" content="../assets/masterpages/Manual_Page.htt" />


### PR DESCRIPTION
There's a number of pages scattered through the manual which don't import the `main_script.js` script for whatever reason, but do use code blocks. This means their GML code blocks are not highlighted. I've used another of my trademarked horrifying regular expressions (`assets/css/default.css" />\n  <[^s][^§]*?class="code"`) to find these pages, and added the missing script tag to each.