### PR TITLE
GLSL code highlighting, audio_emitter_free force-stops sounds, endianness of buffer numbers reading/writing, built-in directory variables

### DIFF
--- a/Manual/contents/Additional_Information/Guide_To_Primitives_And_Vertex_Building.htm
+++ b/Manual/contents/Additional_Information/Guide_To_Primitives_And_Vertex_Building.htm
@@ -81,7 +81,7 @@
   </ul>
   <p>Now, this might look odd as it seems that we can specify more attribute kinds in our vertex format than we can in the vertex shader. However, in the shader <i>Position</i> and <i>3D Position</i> are treated as the <em>same </em>attribute, except that <i>Position</i> is expected to have only &quot;x&quot; and &quot;y&quot; coordinates whereas <i>3D Position</i> has “x”, “y” and “z” coordinates. So how do you map what&#39;s in your vertex format to how you define attributes in your shader? Let&#39;s start by looking at a typical set of attributes from the default shader:</p>
   <p> </p>
-  <p class="code">attribute vec3 in_Position;        // (x,y,z)<br />
+  <p class="code language-glsl">attribute vec3 in_Position;        // (x,y,z)<br />
     //attribute vec3 in_Normal;        // (x,y,z) unused in this shader.<br />
     attribute vec4 in_Colour;          // (r,g,b,a)<br />
     attribute vec2 in_TextureCoord;    // (u,v)</p>
@@ -106,7 +106,7 @@
     vertex_format_add_texcoord();<br />
     my_format = vertex_format_end();</p>
   <p>And now the associated shader attributes:</p>
-  <p class="code">attribute vec3 in_Position;      // (x,y,z)<br />
+  <p class="code language-glsl">attribute vec3 in_Position;      // (x,y,z)<br />
     attribute vec4 in_Colour0;       // (r,g,b,a)<br />
     attribute vec4 in_Colour1;       // (r,g,b,a)<br />
     attribute vec2 in_TextureCoord;  // (u,v)</p>
@@ -120,7 +120,7 @@
     vertex_format_add_texcoord();<br />
     my_format = vertex_format_end();</p>
   <p>And the shader code would look something like this:</p>
-  <p class="code">attribute vec3 in_Position;      // (x,y,z)<br />
+  <p class="code language-glsl">attribute vec3 in_Position;      // (x,y,z)<br />
     attribute vec4 in_Colour;        // (r,g,b,a)<br />
     attribute vec2 in_myTexcoord;    // (u,v)<br />
     attribute vec2 in_TextureCoord;  // (u,v)<br />
@@ -139,7 +139,7 @@
         <div style="float:right">Next: <a href="Guide_To_Using_Blendmodes.htm">Guide To Using Blendmodes</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 Primitive Building

--- a/Manual/contents/Additional_Information/Guide_To_Using_Shaders.htm
+++ b/Manual/contents/Additional_Information/Guide_To_Using_Shaders.htm
@@ -359,7 +359,7 @@
       uniform float u_saturation;<br />
       uniform float u_brightness;<br />
       uniform float u_section;<br />
-      Uniform float u_mix;<br />
+      uniform float u_mix;<br />
       <br />
       vec3 hsv2rgb(vec3 c) <br />
       {<br />
@@ -394,7 +394,7 @@
         <div style="float:right">Next: <a href="Guide_To_Primitives_And_Vertex_Building.htm">Guide To Primitives And Vertex Building</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 Shaders

--- a/Manual/contents/Additional_Information/Guide_To_Using_Shaders.htm
+++ b/Manual/contents/Additional_Information/Guide_To_Using_Shaders.htm
@@ -243,7 +243,7 @@
     <p class="code">// Create Event<br />
       _uniUV = shader_get_uniform(shdrRainbow, &quot;u_uv&quot;);</p>
     <p class="dropspot">And we modify the draw event to get the values and then pass them to the shader:</p>
-    <p class="code language-glsl">// Draw Event<br />
+    <p class="code">// Draw Event<br />
       shader_set(shdrRainbow);<br />
       var uv = sprite_get_uvs(sprite_index, image_index);<br />
       shader_set_uniform_f(_uniUV, uv[0], uv[2]);<br />

--- a/Manual/contents/Additional_Information/Guide_To_Using_Shaders.htm
+++ b/Manual/contents/Additional_Information/Guide_To_Using_Shaders.htm
@@ -16,23 +16,23 @@
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">Guide To Using Shaders</span></h1>
   <p>Shaders are often used to create beautiful graphical effects in games. They are also among the most advanced features offered by <span data-keyref="GameMaker Name">GameMaker</span>, so it is necessary that you have a basic understanding of programming and how <span data-keyref="GameMaker Name">GameMaker</span> works before getting started with them.</p>
-  <p>So, what is a shader? Initially they were created to provide shading for lighting (hence the name), but they are now used to produce a huge variety of effects. Shader code is similar to regular code, but it is (almost always) executed by the GPU, not the CPU. This difference comes with its own set of rules and limitations, but we’ll cover those later.</p>
-  <p>Each shader is made up of two separate components: a <strong>vertex shader </strong>and a <strong>fragment shader </strong>(also referred to as <strong>pixel shader</strong>). Let’s start with the vertex shader. Each sprite is formed by a rectangle, but computers like to draw triangles, so those rectangles are split into two triangles (sometimes called a <em>quad</em>). This leaves us with six vertices (corners) per sprite, but two of those are the same one, so we should only worry about four. Now, imagine we have a for loop that goes over every vertex and executes the code inside the vertex shader for each. This allows us to change the vertex position and color before passing it over to the fragment shader since the vertex shader is executed earlier.</p>
-  <p>Here’s how that would look:</p>
-  <p><img alt="Shader Vertices" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Vertices.gif" />For the fragment shader, you can imagine the same loop as before, but this time it goes over every single pixel in your sprite, giving you information such as location and color of that pixel. In your fragment shader code, you perform operations and calculations to determine the color of that pixel to get the effect you want. For example, if you want a shader to make your sprite be black and white, then you’d calculate which shade of grey each pixel needs to be to create the effect.</p>
+  <p>So, what is a shader? Initially they were created to provide shading for lighting (hence the name), but they are now used to produce a huge variety of effects. Shader code is similar to regular code, but it is (almost always) executed by the GPU, not the CPU. This difference comes with its own set of rules and limitations, but we&#39;ll cover those later.</p>
+  <p>Each shader is made up of two separate components: a <strong>vertex shader </strong>and a <strong>fragment shader </strong>(also referred to as <strong>pixel shader</strong>). Let&#39;s start with the vertex shader. Each sprite is formed by a rectangle, but computers like to draw triangles, so those rectangles are split into two triangles (sometimes called a <em>quad</em>). This leaves us with six vertices (corners) per sprite, but two of those are the same one, so we should only worry about four. Now, imagine we have a for loop that goes over every vertex and executes the code inside the vertex shader for each. This allows us to change the vertex position and color before passing it over to the fragment shader since the vertex shader is executed earlier.</p>
+  <p>Here&#39;s how that would look:</p>
+  <p><img alt="Shader Vertices" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Vertices.gif" />For the fragment shader, you can imagine the same loop as before, but this time it goes over every single pixel in your sprite, giving you information such as location and color of that pixel. In your fragment shader code, you perform operations and calculations to determine the color of that pixel to get the effect you want. For example, if you want a shader to make your sprite be black and white, then you&#39;d calculate which shade of grey each pixel needs to be to create the effect.</p>
   <p>It would look something like this:</p>
-  <p><img alt="Shader Fragments" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Fragments.gif" />The reason shader code is usually executed by the GPU is that it is more efficient at it. Modern CPUs typically have between two to eight cores. Each core can perform one task at a time, so by taking advantage of multiple cores, we can perform that many tasks simultaneously. In contrast, modern GPUs can perform thousands, and even tens of thousands, of tasks running at the same time. This is helpful for shaders because we can execute the shader code of thousands of pixels concurrently. The limitation is that we only have access to the initial state of the sprite, so we don’t know about any modifications done to other pixels since we can’t know for sure the code has run on them yet.</p>
-  <p class="note"><span data-conref="../assets/snippets/Tag_note.hts"> </span> <span data-keyref="GameMaker Name">GameMaker</span> allows users to write shaders in <strong>GLSL</strong> (OpenGL Shader Language), <strong>HLSL</strong> (High-level Shader Language, used when working with DirectX), and <strong>GLSL ES</strong> (a subset of GLSL which is common in mobile devices). Here we are using <strong>GLSL ES</strong> as the shader language since it’s the one that provides the best compatibility across target platforms. Generally this is the one you always want to use unless you have very specific needs and understand the limitation of the other shader languages. The math and techniques should be similar between all three languages however, save for a few syntax differences here and there.</p>
-  <p>The vertex shader is executed first, and as we explained above, it deals with <strong>vertices</strong>. It is used to calculate positions, normals, and texture coordinates. These shaders are not particularly useful in 2D, since every sprite is usually a square, but it can be used to do some skewing, scaling, etc... It becomes much more useful in 3D for lighting calculations and mesh deformations. Fragment shaders are much more interesting and are what will be covered mostly here, since the fragment shader is where we get information about our textures and can tweak the final color of each pixel in our image.</p>
+  <p><img alt="Shader Fragments" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Fragments.gif" />The reason shader code is usually executed by the GPU is that it is more efficient at it. Modern CPUs typically have between two to eight cores. Each core can perform one task at a time, so by taking advantage of multiple cores, we can perform that many tasks simultaneously. In contrast, modern GPUs can perform thousands, and even tens of thousands, of tasks running at the same time. This is helpful for shaders because we can execute the shader code of thousands of pixels concurrently. The limitation is that we only have access to the initial state of the sprite, so we don&#39;t know about any modifications done to other pixels since we can&#39;t know for sure the code has run on them yet.</p>
+  <p class="note"><span data-conref="../assets/snippets/Tag_note.hts"> </span> <span data-keyref="GameMaker Name">GameMaker</span> allows users to write shaders in <strong>GLSL</strong> (OpenGL Shader Language), <strong>HLSL</strong> (High-level Shader Language, used when working with DirectX), and <strong>GLSL ES</strong> (a subset of GLSL which is common in mobile devices). Here we are using <strong>GLSL ES</strong> as the shader language since it&#39;s the one that provides the best compatibility across target platforms. Generally, this is the one you always want to use unless you have very specific needs and understand the limitation of the other shader languages. The math and techniques should be similar between all three languages however, save for a few syntax differences here and there.</p>
+  <p>The vertex shader is executed first, and as we explained above, it deals with <strong>vertices</strong>. It is used to calculate positions, normals, and texture coordinates. These shaders are not particularly useful in 2D, since every sprite is usually a square, but it can be used to do some skewing, scaling, etc. It becomes much more useful in 3D for lighting calculations and mesh deformations. Fragment shaders are much more interesting and are what will be covered mostly here, since the fragment shader is where we get information about our textures and can tweak the final color of each pixel in our image.</p>
   <p> </p>
   <h2>Shader Variables</h2>
-  <p>If you have created a shader in <span data-keyref="GameMaker Name">GameMaker</span>, you might have noticed the following keywords in the default <strong>pass-through</strong> shader. These keywords help the shader understand the purpose and scope of each variable:</p>
+  <p>If you have created a shader in <span data-keyref="GameMaker Name">GameMaker</span>, you might have noticed the following keywords in the default <strong>passthrough</strong> shader. These keywords help the shader understand the purpose and scope of each variable:</p>
   <ul class="colour">
     <li><strong>Attribute</strong>: These are variables passed in by OpenGL to the <strong>vertex </strong>shader. These can change per vertex and are read-only. These include information such as vertex position, texture coordinates, vertex color, and vertex normal.</li>
     <li><strong>Varying</strong>: These are variables used to pass data between the <strong>vertex </strong>and <strong>fragment </strong>shaders. These are available for writing in the vertex shader, but are read-only in the fragment shader.</li>
     <li><strong>Uniform</strong>: These are variables that change per object and are passed by the user to the shader. These can be used in both the vertex and fragment shaders, but are read-only.</li>
   </ul>
-  <p>You&#39;ll also see the use of <strong>vec</strong> as a keyword. This is used to identify a vector variable in the shader and you&#39;ll soon see that vectors are very important when working with shaders. That is why they are implemented as a base type in GLSL. If you are unfamiliar with them, they are a mathematical term represented as a matrix with only one column. In programming, we usually represent them as an array where the number of components corresponds to the dimension. Two and three-dimensional vectors are often used for positions, texture coordinates, or colors without an alpha channel, while four-dimensional ones are used for colors with an alpha channel. We can also specify if they hold booleans, integers, or floating point values. The syntax to declare a vector is this:</p>
+  <p>You&#39;ll also see the use of <span class="inline2">vec</span> as a keyword. This is used to identify a vector variable in the shader and you&#39;ll soon see that vectors are very important when working with shaders. That is why they are implemented as a base type in GLSL. If you are unfamiliar with them, they are a mathematical term represented as a matrix with only one column. In programming, we usually represent them as an array where the number of components corresponds to the dimension. Two and three-dimensional vectors are often used for positions, texture coordinates, or colors without an alpha channel, while four-dimensional ones are used for colors with an alpha channel. We can also specify if they hold booleans, integers, or floating point values. The syntax to declare a vector is this:</p>
   <p class="code language-glsl">vec2 firstVec;  // Two-dimensional vector of floats<br />
     vec3 secondVec; // Three-dimensional vector of floats<br />
     vec4 thirdVec;  // Four-dimensional vector of floats<br />
@@ -62,21 +62,21 @@
   <p class="code language-glsl">vec4 myVec;<br />
     myVec.x = 0.0;<br />
     myVec.y = 1.0;</p>
-  <p>This uses the component names inside the vector to access them. You can use x, y, z, or w, to get the first, second, third, or fourth components, respectively. We refer to this method as <strong>swizzling </strong>because the following syntax is also valid:</p>
+  <p>This uses the component names inside the vector to access them. You can use <span class="inline2">x</span>, <span class="inline2">y</span>, <span class="inline2">z</span>, or <span class="inline2">w</span>, to get the first, second, third, or fourth components, respectively. We refer to this method as <strong>swizzling </strong>because the following syntax is also valid:</p>
   <p class="code language-glsl">vec4 firstVec;<br />
     vec3 secondVec = firstVec.xyz;<br />
     vec2 thirdVec  = secondVec.zy;<br />
     vec4 fourthVec = thirdVec.yxxy;</p>
-  <p>As you can see, we can use any combination of up to four letters to create a vector of that length. We cannot attempt to access a component that would be out of bounds (for example, trying to access w in <span class="inline">secondVec</span> or <span class="inline">thirdVec</span>, since they don’t have a fourth component). Also, we can repeat letters and use them in any order, as long as the vector variable it’s being assigned to is the same size as the number of letters used.</p>
-  <p>For obvious reasons, when using swizzle to set component values, you can’t use the same component twice. For example, the below is not valid as you are trying to set the same component to two different values:</p>
+  <p>As you can see, we can use any combination of up to four letters to create a vector of that length. We cannot attempt to access a component that would be out of bounds (for example, trying to access <span class="inline2">w</span> in <span class="inline2">secondVec</span> or <span class="inline2">thirdVec</span>, since they don&#39;t have a fourth component). Also, we can repeat letters and use them in any order, as long as the vector variable it&#39;s being assigned to is the same size as the number of letters used.</p>
+  <p>For obvious reasons, when using swizzle to set component values, you can&#39;t use the same component twice. For example, the below is not valid as you are trying to set the same component to two different values:</p>
   <p class="code language-glsl">myVec.xx = vec2(2.0, 3.0);</p>
-  <p>Last, we have been using <span class="inline">xyzw</span> as our swizzle mask, which is usually the case when dealing with positions. There are two more sets of masks you can use: <span class="inline">rgba</span> (used for colors), or <span class="inline">stpq</span> (used for texture coordinates). Internally, there is no difference between these masks, and we only use them to make the code clearer as to what the vector represents in that instance. Also, we can’t combine swizzle masks in the same operation, so this is invalid:</p>
+  <p>Last, we have been using <span class="inline2">xyzw</span> as our swizzle mask, which is usually the case when dealing with positions. There are two more sets of masks you can use: <span class="inline2">rgba</span> (used for colors), or <span class="inline2">stpq</span> (used for texture coordinates). Internally, there is no difference between these masks, and we only use them to make the code clearer as to what the vector represents in that instance. Also, we can&#39;t combine swizzle masks in the same operation, so this is invalid:</p>
   <p class="code language-glsl"><span class="inline"></span>myVec = otherVec.ybp;</p>
   <p>Those were a lot of definitions and information, but knowing these things is necessary to understand shaders themselves.</p>
   <p> </p>
   <h2>Creating A Shader</h2>
-  <p>When you create a shader in <span data-keyref="GameMaker Name">GameMaker</span>, it will open two files for you: a vertex shader (<span class="inline">.vsh</span>) and a fragment shader (<span class="inline">.fsh</span>). This is the most basic shader you can make, which takes a sprite, reads the texture, and colors each pixel with that color. If you specify vertex colors when drawing, those colors will blend with the texture.</p>
-  <p>Let’s go through the code for a newly created shader asset and analyze it, starting with the vertex shader.</p>
+  <p>When you create a shader in <span data-keyref="GameMaker Name">GameMaker</span>, it will open two files for you: a vertex shader (<span class="inline2">.vsh</span>) and a fragment shader (<span class="inline2">.fsh</span>). This is the most basic shader you can make, which takes a sprite, reads the texture, and colors each pixel with that color. If you specify vertex colors when drawing, those colors will blend with the texture.</p>
+  <p>Let&#39;s go through the code for a newly created shader asset and analyze it, starting with the vertex shader.</p>
   <p class="code language-glsl">// Passthrough Vertex Shader<br />
     attribute vec3 in_Position;                  // (x,y,z)<br />
     //attribute vec3 in_Normal;                  // (x,y,z)     unused in this shader.<br />
@@ -95,14 +95,14 @@
         v_vTexcoord = in_TextureCoord;<br />
     }
   </p>
-  <p>Outside of the main function, we see some variable declarations and their qualifiers. The attributes are given to us by GameMaker. The varying ones are created by the user to pass that information over to the fragment shader. Inside the main function, we have the calculations to find the screen position of the vertex:</p>
+  <p>Outside of the main function, we see some variable declarations and their qualifiers. The attributes are given to us by <span data-keyref="GameMaker Name">GameMaker</span>. The varying ones are created by the user to pass that information over to the fragment shader. Inside the main function, we have the calculations to find the screen position of the vertex:</p>
   <ul class="colour">
-    <li>First, we create a <span class="inline">vec4</span> and initialize it with the components of the position, adding one as the fourth component. In linear algebra, the convention is that we add a one to the fourth component if the vector is representing a point, or a zero if it represents an actual vector.</li>
-    <li>Next, we need to add this fourth component to multiply it with the <span class="inline">MATRIX_WORLD_VIEW_PROJECTION</span> matrix, which is a 4x4 matrix. This multiplication will project the world position of the vertex into screen coordinates.</li>
-    <li>Finally we pass the vertex color and texture coordinate to the fragment shader through our varying variables.</li>
+    <li>First, we create a <span class="inline2">vec4</span> and initialize it with the components of the position, adding one as the fourth component. In linear algebra, the convention is that we add a one to the fourth component if the vector is representing a point, or a zero if it represents an actual vector.</li>
+    <li>Next, we need to add this fourth component to multiply it with the <span class="inline2">MATRIX_WORLD_VIEW_PROJECTION</span> matrix, which is a 4x4 matrix. This multiplication will project the local position of the vertex into screen coordinates.</li>
+    <li>Finally, we pass the vertex color and texture coordinate to the fragment shader through our varying variables.</li>
   </ul>
   <p>This shader should be left alone if you are not planning to play with vertex positions and it will not be used in any of the examples given below because all the effects shown will be created using the fragment shader.</p>
-  <p>Let’s take a quick look at the fragment shader now:</p>
+  <p>Let&#39;s take a quick look at the fragment shader now:</p>
   <p class="code language-glsl">// Passthrough Fragment Shader<br />
     varying vec2 v_vTexcoord;<br />
     varying vec4 v_vColour;<br />
@@ -112,28 +112,28 @@
         gl_FragColor = v_vColour * texture2D( gm_BaseTexture, v_vTexcoord );<br />
     }
   </p>
-  <p>As explained before, the idea behind a fragment shader is to return the color of the current pixel. This is done by assigning the variable <span class="inline">gl_FragColor</span> the final color value. The <span class="inline">texture2D</span> function takes a texture and a <span class="inline">vec2</span> with the UV coordinates you want to check in that texture, which returns a <span class="inline">vec4</span> with the color. In the pass through shader, all we are doing is grabbing the color of the texture in the coordinate of this pixel and multiplying it by the color of the vertex associated with this pixel.</p>
+  <p>As explained before, the idea behind a fragment shader is to return the color of the current pixel. This is done by assigning the variable <span class="inline2">gl_FragColor</span> the final color value. The <span class="inline3_func">texture2D</span> function takes a texture and a <span class="inline2">vec2</span> with the UV coordinates you want to check in that texture, which returns a <span class="inline2">vec4</span> with the color. In the passthrough shader, all we are doing is grabbing the color of the texture at the coordinate of this pixel and multiplying it by the color of the vertex associated with this pixel.</p>
   <p>Now that we have our first shader, all we have to do to test it is create an object and assign it a sprite, then in the <strong>Draw Event</strong> of the object you set the shader like this:</p>
   <p class="code">// Draw Event<br />
     shader_set(shdrColorOverlay);<br />
     draw_self();<br />
     shader_reset();</p>
-  <p>Every draw call we make between <a href="../GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_set.htm"><span class="inline">shader_set()</span></a> and <a href="../GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_reset.htm"><span class="inline">shader_reset()</span></a> will have the shader applied to it. Here, we are drawing the object sprite with our passthrough shader:</p>
-  <p><img alt="Drawing Sprite Using Passthough Shader" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_PassThrough.gif" />As you might have guessed, this does not visually changing anything, as this is a simple pass-through shader. However the sections below outline some simple steps you can take to modify this and change the way the sprite will be drawn. Each of the section shows a different shader that you can create and use in your projects, explaining the steps required to create them and why we are doing things the way we are.</p>
+  <p>Every draw call we make between <span class="inline3_func"><a data-xref="{title}" href="../GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_set.htm">shader_set</a></span> and <span class="inline3_func"><a data-xref="{title}" href="../GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_reset.htm">shader_reset</a></span> will have the shader applied to it. Here, we are drawing the object sprite with our passthrough shader:</p>
+  <p><img alt="Drawing Sprite Using Passthough Shader" class="center" height="322" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_PassThrough.gif" width="393" />As you might have guessed, this does not visually changing anything, as this is a simple passthrough shader. However, the sections below outline some simple steps you can take to modify this and change the way the sprite will be drawn. Each of the sections shows a different shader that you can create and use in your projects, explaining the steps required to create them and why we are doing things the way we are.</p>
   <p> </p>
   <p><a class="dropspot" data-rhwidget="DropSpot" data-target="drop-down" href="#">Colour Overlay Shader</a></p>
   <div class="droptext" data-targetname="drop-down">
-    <p class="dropspot">We can edit the base shader now to do something different. We&#39;ll not be touching the vertex shader part, and only editing the fragment shader, and to start with we&#39;ll do a very simple operation, which is to make the shader draw the sprite using the colour red. We&#39;ll do this by simply changing the <span class="inline">gl_FragColor</span> to be red., like this:</p>
+    <p class="dropspot">We can edit the base shader now to do something different. We&#39;ll not be touching the vertex shader part, and only editing the fragment shader, and to start with we&#39;ll do a very simple operation, which is to make the shader draw the sprite using the colour red. We&#39;ll do this by simply changing the <span class="inline2">gl_FragColor</span> to be red, like this:</p>
     <p class="code language-glsl">// Color Overlay Fragment Shader<br />
       void main()<br />
       {<br />
           gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);<br />
       }</p>
     <p class="dropspot">This will give us the following result:</p>
-    <p class="dropspot"><img alt="Initial Colour Overlay Block" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_ColourOverlay_Block.gif" />Not exactly what we expected! What we need to remember is that every sprite is ultimately a rectangle, so unless we consider transparency - which we haven&#39;t - this is the result we’ll get.</p>
-    <p class="note"><span data-conref="../assets/snippets/Tag_note.hts"> </span> In the image above, the rectangle changes size because the base sprite has had the &quot;empty&quot; space around it cropped automatically when it was placed on the texture page by GameMaker, so each animation frame the triangles that make it up are different sizes to fit the cropped size of the frame. If you disable this option, then you&#39;d simply have a motionless red square on the screen.</p>
-    <p class="dropspot">Above we mentioned the <span class="inline">texture2D</span> function, and we&#39;ll use that to grab the color at the pixel we are working on and get the transparency from it. The return value of is <span class="inline">texture2D</span> is a <span class="inline">vec4</span>, where the components are the red, green, blue, and alpha, in that order. We can access the alpha channel either by putting a period followed by an <span class="inline">a</span> or a <span class="inline">w</span> after the variable name. This corresponds to RGBA and XYZW, respectively.</p>
-    <p class="dropspot">Here’s the updated code:</p>
+    <p class="dropspot"><img alt="Initial Colour Overlay Block" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_ColourOverlay_Block.gif" />Not exactly what we expected! What we need to remember is that every sprite is ultimately a rectangle, so unless we consider transparency - which we haven&#39;t - this is the result we&#39;ll get.</p>
+    <p class="note"><span data-conref="../assets/snippets/Tag_note.hts"> </span> In the image above, the rectangle changes size because the base sprite has had the &quot;empty&quot; space around it cropped automatically when it was placed on the texture page by <span data-keyref="GameMaker Name">GameMaker</span>, so each animation frame the triangles that make it up are different sizes to fit the cropped size of the frame. If you disable this option, then you&#39;d simply have a motionless red square on the screen.</p>
+    <p class="dropspot">Above we mentioned the <span class="inline3_func">texture2D</span> function, and we&#39;ll use that to grab the color at the pixel we are working on and get the transparency from it. The return value of <span class="inline3_func">texture2D</span> is a <span class="inline2">vec4</span>, where the components are the red, green, blue, and alpha, in that order. We can access the alpha channel either by putting a period followed by an <span class="inline2">a</span> or a <span class="inline2">w</span> after the variable name. This corresponds to RGBA and XYZW, respectively.</p>
+    <p class="dropspot">Here&#39;s the updated code:</p>
     <p class="code language-glsl">// Color Overlay Fragment Shader<br />
       varying vec2 v_vTexcoord;<br />
       <br />
@@ -143,20 +143,20 @@
           gl_FragColor = vec4(1.0, 0.0, 0.0, texColor.a);<br />
       }
     </p>
-    <p class="dropspot">We are now assigning a new <span class="inline">vec4</span> to <span class="inline">gl_FragColor</span>, where the red channel is maxed, the green, and blue channels are zero, and the alpha channel is the same as the original texture. The output looks like this:</p>
-    <p class="dropspot"><img alt="Overlay Shader Making Sprite Red" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_ColourOverlay.gif" />Now that’s what we were after! We have replaced the color of every pixel with red, but have kept the alpha channel intact.</p>
-    <p class="dropspot">Having to change the shader each time we want to use a different color isn’t a good idea, especially since we’d need to have a separate shader for each color we want. Instead, we will pass the color information to the shader using a <strong>uniform</strong>. To do this, we first need to get a <strong>pointer </strong>to the uniform. We will do this in the <strong>Create Event</strong> of our object that has the sprite by adding:</p>
+    <p class="dropspot">We are now assigning a new <span class="inline2">vec4</span> to <span class="inline2">gl_FragColor</span>, where the red channel is maxed, the green and blue channels are zero, and the alpha channel is the same as the original texture. The output looks like this:</p>
+    <p class="dropspot"><img alt="Overlay Shader Making Sprite Red" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_ColourOverlay.gif" />Now that&#39;s what we were after! We have replaced the color of every pixel with red, but have kept the alpha channel intact.</p>
+    <p class="dropspot">Having to change the shader each time we want to use a different color isn&#39;t a good idea, especially since we&#39;d need to have a separate shader for each color we want. Instead, we will pass the color information to the shader using a <strong>uniform</strong>. To do this, we first need to get a <strong>pointer </strong>to the uniform. We will do this in the <strong>Create Event</strong> of our object that has the sprite by adding:</p>
     <p class="code">// Create Event<br />
       _uniColor = shader_get_uniform(shdrColorOverlay, &quot;u_colour&quot;);<br />
       _color    = [1.0, 1.0, 0.0, 1.0];</p>
-    <p class="dropspot">All we need to do is call <a href="../GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_get_uniform.htm"><span class="inline">shader_get_uniform()</span></a> to get a pointer to the uniform. The parameters we need to pass are the shader asset name (without quotation because we want to pass the ID that GameMaker generates for us) and the name of the uniform variable inside of the shader, this time as a string. This name needs to match exactly the one inside the shader code for it to work. We have also added a colour variable so we can change it at runtime and have it remember our changes.</p>
-    <p class="dropspot">Now the code in our draw event will change slightly to pass the uniform variable.</p>
+    <p class="dropspot">All we need to do is call <span class="inline3_func"><a data-xref="{title}" href="../GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_get_uniform.htm">shader_get_uniform</a></span> to get a pointer to the uniform. The parameters we need to pass are the shader asset name (without quotation because we want to pass the ID that <span data-keyref="GameMaker Name">GameMaker</span> generates for us) and the name of the uniform variable inside of the shader, this time as a string. This name needs to match exactly the one inside the shader code for it to work. We have also added a colour variable so we can change it at runtime and have it remember our changes.</p>
+    <p class="dropspot">Now the code in our Draw event will change slightly to pass the uniform variable.</p>
     <p class="code">// Draw Event<br />
       shader_set(shdrColorOverlay);<br />
       shader_set_uniform_f_array(_uniColor, _color);<br />
       draw_self();<br />
       shader_reset();</p>
-    <p class="dropspot">It’s the same code as before, but before we draw anything, we need to pass all the uniform values to the shader. In this case, we are passing the color as an array of floats. As for the shader, we will change it to include the uniform and use it, so it becomes:</p>
+    <p class="dropspot">It&#39;s the same code as before, but before we draw anything, we need to pass all the uniform values to the shader. In this case, we are passing the color as an array of floats. As for the shader, we will change it to include the uniform and use it, so it becomes:</p>
     <p class="code language-glsl">// Color Overlay Fragment Shader<br />
       varying vec2 v_vTexcoord;<br />
       uniform vec4 u_colour;<br />
@@ -165,14 +165,14 @@
           vec4 texColor = texture2D(gm_BaseTexture, v_vTexcoord);<br />
           gl_FragColor = vec4(u_colour.rgb, texColor.a);<br />
       }</p>
-    <p class="dropspot">We declare a variable with the same name as in the create shader (<span class="inline">u_colour</span>) and we pass it as the first three components of the <span class="inline">gl_FragColor</span> vector, taking advantage of swizzling. If we compile again, we should see this:</p>
-    <p class="dropspot"><img alt="Overlay Shader Making Sprite Yellow" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_ColourOverlay_Yellow.gif" />Now the shader is much more useful and reusable. It’s up to you to add more functionality if you need it to set the color (using the variable <span class="inline">_color</span>) during runtime.</p>
+    <p class="dropspot">We declare a variable with the same name as in the create shader (<span class="inline2">u_colour</span>) and we pass it as the first three components of the <span class="inline2">gl_FragColor</span> vector, taking advantage of swizzling. If we compile again, we should see this:</p>
+    <p class="dropspot"><img alt="Overlay Shader Making Sprite Yellow" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_ColourOverlay_Yellow.gif" />Now the shader is much more useful and reusable. It&#39;s up to you to add more functionality if you need it to set the color (using the variable <span class="inline2">_color</span>) during runtime.</p>
     <p> </p>
   </div>
   <p><a class="dropspot" data-rhwidget="DropSpot" data-target="drop-down1" href="#">Black And White Shader</a></p>
   <div class="droptext" data-targetname="drop-down1">
     <p class="dropspot">Making a black and white shader is a great way to learn more about how shaders work, and a lot of beginners start by trying to do this, since conceptually it&#39;s quite simple: get every pixel and assign it a shade of gray. But is it simple? Not quite...</p>
-    <p class="dropspot">When using RGB colour, if all three components are the same value, then we get a gray tone. The naïve approach to creating a shader to use this idea would be to add all three color channels (red, green, and blue) and then divide it by three. After that you&#39;d assigned the value to all three channels, thus creating a gray tone. Here’s what that fragment shader looks like:</p>
+    <p class="dropspot">When using RGB colour, if all three components are the same value, then we get a gray tone. The naïve approach to creating a shader to use this idea would be to add all three color channels (red, green, and blue) and then divide it by three. After that you&#39;d assigned the value to all three channels, thus creating a gray tone. Here&#39;s what that fragment shader looks like:</p>
     <p class="code language-glsl">// Black and white fragment shader<br />
       varying vec2 v_vTexcoord;<br />
       varying vec4 v_vColour;<br />
@@ -184,14 +184,14 @@
           gl_FragColor = v_vColour * vec4(gray, gray, gray, texColor.a);<br />
       }
     </p>
-    <p class="dropspot">One thing you might have noticed is that in the <span class="inline">gl_FragColor</span> code, we&#39;re multiplying the <span class="inline">vec4</span> with something called <span class="inline">v_vColour</span>. This is a variable passed by the vertex shader which tells us the color of the vertex associated with this pixel. It’s always a good idea to multiply your final calculated color with the vertex color. In most cases, it won’t do anything, but if you changed the vertex color in GML, this will reflect that (by using functions such as <a href="../GameMaker_Language/GML_Reference/Drawing/Sprites_And_Tiles/draw_sprite_ext.htm"><span class="inline">draw_sprite_ext()</span></a> or <a href="../GameMaker_Language/GML_Reference/Drawing/Sprites_And_Tiles/draw_sprite_general.htm"><span class="inline">draw_sprite_general()</span></a> to change the <a href="../GameMaker_Language/GML_Reference/Asset_Management/Sprites/Sprite_Instance_Variables/image_blend.htm"><span class="inline">image_blend</span></a>).</p>
-    <p class="dropspot">As for the draw event, it’s quite simple since we don’t have a uniform to pass in:</p>
+    <p class="dropspot">One thing you might have noticed is that in the <span class="inline2">gl_FragColor</span> code, we&#39;re multiplying the <span class="inline2">vec4</span> with something called <span class="inline2">v_vColour</span>. This is a variable passed by the vertex shader which tells us the color of the vertex associated with this pixel. It&#39;s always a good idea to multiply your final calculated color with the vertex color. In most cases, it won&#39;t do anything, but if you changed the vertex color in GML, this will reflect that (by using functions such as <span class="inline3_func"><a data-xref="{title}" href="../GameMaker_Language/GML_Reference/Drawing/Sprites_And_Tiles/draw_sprite_ext.htm">draw_sprite_ext</a></span> or <span class="inline3_func"><a data-xref="{title}" href="../GameMaker_Language/GML_Reference/Drawing/Sprites_And_Tiles/draw_sprite_general.htm">draw_sprite_general</a></span> to change the <span class="inline3_func"><a data-xref="{title}" href="../GameMaker_Language/GML_Reference/Asset_Management/Sprites/Sprite_Instance_Variables/image_blend.htm">image_blend</a></span>).</p>
+    <p class="dropspot">As for the Draw event, it&#39;s quite simple since we don&#39;t have a uniform to pass in:</p>
     <p class="code">// Draw Event<br />
       shader_set(shdrBlackAndWhite);<br />
       draw_self();<br />
       shader_reset();</p>
-    <p class="dropspot">Let’s compile and see what we got.</p>
-    <p class="dropspot"><img alt="Black And White Shader" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_BlackAndWhite.gif" />This looks great already, right? Well, yes and no... there is a solution that is more “correct”, since instead of adding the components and dividing by three, we multiply each component by the standard NTSC values for black and white. Here’s the modified fragment shader code:</p>
+    <p class="dropspot">Let&#39;s compile and see what we got.</p>
+    <p class="dropspot"><img alt="Black And White Shader" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_BlackAndWhite.gif" />This looks great already, right? Well, yes and no... there is a solution that is more &quot;correct&quot;, since instead of adding the components and dividing by three, we multiply each component by the standard NTSC values for black and white. Here&#39;s the modified fragment shader code:</p>
     <p class="code language-glsl">// Black and white fragment shader<br />
       varying vec2 v_vTexcoord;<br />
       <br />
@@ -202,17 +202,17 @@
           gl_FragColor = vec4(gray, gray, gray, texColor.a);<br />
       }
     </p>
-    <p class="dropspot">We use the dot product as a shorthand for multiplying each component of <span class="inline">texColor</span> with the correct weights and then add them together. If you are unfamiliar with the dot product, this is essentially what’s happening:</p>
+    <p class="dropspot">We use the dot product as a shorthand for multiplying each component of <span class="inline2">texColor</span> with the correct weights and then add them together. If you are unfamiliar with the dot product, this is essentially what&#39;s happening:</p>
     <p class="code language-glsl">float gray = (texColor.r * 0.299) + (texColor.g * 0.587) + (texColor.b * 0.114);</p>
-    <p class="dropspot">In the end, it looks very similar, but it’s technically more correct.</p>
+    <p class="dropspot">In the end, it looks very similar, but it&#39;s technically more correct.</p>
     <p class="dropspot"><img alt="Corrected Black And White Shader" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_BlackAndWhite_Improved.gif" /></p>
     <p class="dropspot"> </p>
   </div>
   <p><a class="dropspot" data-rhwidget="DropSpot" data-target="drop-down2" href="#">Rainbow Shader</a></p>
   <div class="droptext" data-targetname="drop-down2">
     <p class="dropspot">Our final shader example is a fun one and can be used to add life to text and buttons and other things. We&#39;ll start simple and add functionality gradually since this shader is highly customizable. There&#39;s quite a lot to cover for this one, so if you feel a bit lost or confused, please go back and re-read some of the sections above.</p>
-    <p class="dropspot">The first thing we want to do is color pixels with every hue, depending on the pixel’s horizontal position. The way to do this is to set the x position to be the hue and then convert from HSV (hue, saturation, brightness) format to RGB (red, green, and blue) format. For this, we will need to write a helper function in our fragment shader that takes HSV values and returns an RGB vector. We will use a single function which does this without the need for any <span class="inline">if</span> statements, as using conditionals in shader code makes shaders <em>very </em>slow, and should be avoided.</p>
-    <p class="dropspot">Here’s what the shader looks like at this stage:</p>
+    <p class="dropspot">The first thing we want to do is color pixels with every hue, depending on the pixel&#39;s horizontal position. The way to do this is to set the x position to be the hue and then convert from HSV (hue, saturation, brightness) format to RGB (red, green, and blue) format. For this, we will need to write a helper function in our fragment shader that takes HSV values and returns an RGB vector. We will use a single function which does this without the need for any <span class="inline2">if</span> statements, as using conditionals in shader code makes shaders <em>very </em>slow, and should be avoided.</p>
+    <p class="dropspot">Here&#39;s what the shader looks like at this stage:</p>
     <p class="code language-glsl">// Fragment Shader<br />
       varying vec2 v_vTexcoord;<br />
       varying vec4 v_vColour;<br />
@@ -231,25 +231,25 @@
           gl_FragColor = v_vColour * vec4(hsv2rgb(col), alpha);<br />
       }
     </p>
-    <p class="dropspot">There&#39;s a bit more going on here than in the previous examples, but most of it should be fairly obvious to you now. First, there’s our <span class="inline">hsv2rgb</span> function, which takes a <span class="inline">vec3</span> with our HSV colour and returns another <span class="inline">vec3</span> with our RGB conversion. In the main function, we start by creating our HSV colour, where the hue is our x position, and we’ll leave the saturation and brightness as 1.0 for now. Then, we get the alpha from the texture so it only colors our sprite character and not the entire sprite rectangle (as we did in the colour overlay example, above). Lastly, we set our Fragment color to be our HSV color converted to RGB with the alpha, multiplied by the vertex color (good practice to do this always).</p>
+    <p class="dropspot">There&#39;s a bit more going on here than in the previous examples, but most of it should be fairly obvious to you now. First, there&#39;s our <span class="inline2">hsv2rgb</span> function, which takes a <span class="inline2">vec3</span> with our HSV colour and returns another <span class="inline2">vec3</span> with our RGB conversion. In the main function, we start by creating our HSV colour, where the hue is our x position, and we&#39;ll leave the saturation and brightness as 1.0 for now. Then, we get the alpha from the texture so it only colors our sprite character and not the entire sprite rectangle (as we did in the colour overlay example, above). Lastly, we set our Fragment color to be our HSV color converted to RGB with the alpha, multiplied by the vertex color (good practice to do this always).</p>
     <p class="dropspot">As for our draw code, it is trivial at the moment:</p>
     <p class="code">// Draw Event<br />
       shader_set(shdrRainbow);<br />
       draw_self();<br />
       shader_reset();</p>
-    <p class="dropspot">Let’s check out what we got:</p>
-    <p class="dropspot"><img alt="Initial Rainbow Shader" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Rainbow_Overlay.gif" />We are close to what we want, but there’s an issue: we are not seeing all the colors at once in every frame of the animation, and the colors seem to change randomly. The reason is that we assumed that <span class="inline">v_vTexcoord</span> gave us the coordinates of the sprite, starting at the top-left corner (0,0) and ending in the bottom right corner (1,1), which is standard in shaders. However, for optimization, GameMaker stuffs as many textures together as it can fit in what is called a <a href="../Settings/Texture_Information/Texture_Pages.htm">texture page,</a> and because of that, this is how our texture actually looks:</p>
-    <p class="dropspot"><img class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Texture.png" />As explained above, <span class="inline">v_vTexcoord</span> gives us the absolute coordinates of the sprite within this entire texture page, but what we want is a value from 0.0 to 1.0 that only covers our current sprite. This process is called <strong>normalizing</strong> (getting a value and translating it to a 0 to 1 range). To normalize our horizontal values, we need to know the values of x0 and x1 in the picture above. Luckily, GameMaker has a function that gives us the location of every corner in our sprite within the texture page. First, we need to go to the Create Event and create a uniform to pass this data over to the shader:</p>
+    <p class="dropspot">Let&#39;s check out what we got:</p>
+    <p class="dropspot"><img alt="Initial Rainbow Shader" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Rainbow_Overlay.gif" />We are close to what we want, but there&#39;s an issue: we are not seeing all the colors at once in every frame of the animation, and the colors seem to change randomly. The reason is that we assumed that <span class="inline2">v_vTexcoord</span> gave us the coordinates of the sprite, starting at the top-left corner (0, 0) and ending in the bottom-right corner (1, 1), which is standard in shaders. However, for optimization, <span data-keyref="GameMaker Name">GameMaker</span> stuffs as many textures together as it can fit in what is called a <a href="../Settings/Texture_Information/Texture_Pages.htm">texture page,</a> and because of that, this is how our texture actually looks:</p>
+    <p class="dropspot"><img class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Texture.png" />As explained above, <span class="inline2">v_vTexcoord</span> gives us the absolute coordinates of the sprite within this entire texture page, but what we want is a value from 0.0 to 1.0 that only covers our current sprite. This process is called <strong>normalizing</strong> (getting a value and translating it to a 0 to 1 range). To normalize our horizontal values, we need to know the values of x0 and x1 in the picture above. Luckily, <span data-keyref="GameMaker Name">GameMaker</span> has a function that gives us the location of every corner in our sprite within the texture page. First, we need to go to the Create Event and create a uniform to pass this data over to the shader:</p>
     <p class="code">// Create Event<br />
       _uniUV = shader_get_uniform(shdrRainbow, &quot;u_uv&quot;);</p>
-    <p class="dropspot">And we modify the draw event to get the values and then pass them to the shader:</p>
+    <p class="dropspot">And we modify the Draw event to get the values and then pass them to the shader:</p>
     <p class="code">// Draw Event<br />
       shader_set(shdrRainbow);<br />
       var uv = sprite_get_uvs(sprite_index, image_index);<br />
       shader_set_uniform_f(_uniUV, uv[0], uv[2]);<br />
       draw_self();<br />
       shader_reset();</p>
-    <p class="dropspot">The function <a href="../GameMaker_Language/GML_Reference/Asset_Management/Sprites/Sprite_Information/sprite_get_uvs.htm"><span class="inline">sprite_get_uvs()</span></a> takes a sprite and an index, and it returns an array with tons of information, such as the coordinates for each corner, how many pixels were cropped to optimize it, etc. We are interested in two of those values: the left and right coordinates of the sprite, which are stored in <span class="inline">uv[0]</span> and <span class="inline">uv[2]</span> respectively. In the fragment shader, we will use those values now to calculate the normalized horizontal position like this:</p>
+    <p class="dropspot">The function <span class="inline3_func"><a data-xref="{title}" href="../GameMaker_Language/GML_Reference/Asset_Management/Sprites/Sprite_Information/sprite_get_uvs.htm">sprite_get_uvs</a></span> takes a sprite and an index, and it returns an array with tons of information, such as the coordinates for each corner, how many pixels were cropped to optimize it, etc. We are interested in two of those values: the left and right coordinates of the sprite, which are stored in <span class="inline2">uv[0]</span> and <span class="inline2">uv[2]</span> respectively. In the fragment shader, we will use those values now to calculate the normalized horizontal position like this:</p>
     <p class="code language-glsl">// Fragment Shader<br />
       varying vec2 v_vTexcoord;<br />
       varying vec4 v_vColour;<br />
@@ -271,7 +271,7 @@
           gl_FragColor = v_vColour * vec4(hsv2rgb(col), alpha);<br />
       }
     </p>
-    <p class="dropspot">Here we add the uniform variable at the top of the file with the same name we used in the Create Event. Next, we calculate the normalized horizontal position by translating our current <span class="inline">x</span> coordinate to the origin ( <span class="inline">v_vTexcoord.x - u_uv[0]</span>) and then we divide it by the width of the sprite to make the range from 0 to 1 (<span class="inline">u_uv[1] - u_uv[0]</span>).</p>
+    <p class="dropspot">Here we add the uniform variable at the top of the file with the same name we used in the Create Event. Next, we calculate the normalized horizontal position by translating our current <span class="inline">x</span> coordinate to the origin ( <span class="inline2">v_vTexcoord.x - u_uv[0]</span>) and then we divide it by the width of the sprite to make the range from 0 to 1 (<span class="inline2">u_uv[1] - u_uv[0]</span>).</p>
     <p class="dropspot">The result is:</p>
     <p class="dropspot"><img alt="Rainbow Overlay Shader Improved" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Rainbow_Overlay_Improved.gif" />There we go! This is exactly what we wanted. We can see every color of the spectrum inside our sprite.</p>
     <p class="dropspot">You might be happy with that, but we can have some more fun with this shader. What if we added an offset to the colors based around time to produce movement? To do this, we will need two extra variables for <strong>speed </strong>and <strong>time</strong>. We will also need two more uniforms, one for each of the new variables, so the Create Event becomes:</p>
@@ -284,7 +284,7 @@
     <p class="dropspot">We also need to increase the time every frame, so in the Step Event we add:</p>
     <p class="code">// Step Event<br />
       _time += 1 / game_get_speed(gamespeed_fps);</p>
-    <p class="dropspot">Let’s go to the draw event now to send these uniforms to the shader:</p>
+    <p class="dropspot">Let&#39;s go to the Draw event now to send these uniforms to the shader:</p>
     <p class="code">// Draw Event<br />
       shader_set(shdrRainbow);<br />
       var uv = sprite_get_uvs(sprite_index, image_index);<br />
@@ -318,7 +318,7 @@
       }
     </p>
     <p class="dropspot">If you did everything correctly, you should be seeing something like this:</p>
-    <p class="dropspot"><img alt="Rainbow Shader Overlay Moving With Time" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Rainbow_Overlay_Final.gif" />To finish this shader, we will add a few more uniforms to customize it even further. The first two are to control the saturation and brightness. The next one we&#39;ll call &quot;section&quot; and its function is to allow the user to pass a number between zero and one to determine what percentage of the entire spectrum we see at a time. Last, we will add a variable called &quot;mix&quot;, which will specify how much we want to mix our shader color with the original texture color (1.0 is all rainbow, 0.0 is all texture). As always, let’s start by adding the variables to the Create Event:</p>
+    <p class="dropspot"><img alt="Rainbow Shader Overlay Moving With Time" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_Rainbow_Overlay_Final.gif" />To finish this shader, we will add a few more uniforms to customize it even further. The first two are to control the saturation and brightness. The next one we&#39;ll call &quot;section&quot; and its function is to allow the user to pass a number between zero and one to determine what percentage of the entire spectrum we see at a time. Last, we will add a variable called <span class="inline2">_mix</span>, which will specify how much we want to mix our shader color with the original texture color (1.0 is all rainbow, 0.0 is all texture). As always, let&#39;s start by adding the variables to the Create Event:</p>
     <p class="code">// Create Event<br />
       _uniUV         = shader_get_uniform(shdrRainbow, &quot;u_uv&quot;);<br />
       _uniTime       = shader_get_uniform(shdrRainbow, &quot;u_time&quot;);<br />
@@ -335,7 +335,7 @@
       _brightness = 0.8;<br />
       _mix = 0.5;
     </p>
-    <p class="dropspot">Our draw event changes to include these uniforms like this:</p>
+    <p class="dropspot">Our Draw event changes to include these uniforms like this:</p>
     <p class="code">// Draw Event<br />
       shader_set(shdrRainbow);<br />
       var uv = sprite_get_uvs(sprite_index, image_index);<br />
@@ -384,14 +384,14 @@
     <p class="dropspot"> </p>
   </div>
   <p> </p>
-  <p>That&#39;s the end of this short guide and you should now have a better understanding of how shaders work and some of the uses they can be put to. You should take your time to play with the shaders you&#39;ve created following this guide, and try to experiment with them do other things - how about creating a blur shader, or a shader that makes a gameboy-style monochrome screen? - since shaders are an incredibly powerful tool for adding visual complexity and style to your games.</p>
+  <p>That&#39;s the end of this short guide. You should now have a better understanding of how shaders work and some of the uses they can be put to. You should take your time to play with the shaders you&#39;ve created following this guide, and try to experiment with them to do other things - how about creating a blur shader, or a shader that makes a Game Boy-style monochrome screen? - since shaders are an incredibly powerful tool for adding visual complexity and style to your games.</p>
   <p class="note">We would like to thank <a href="https://twitter.com/AleHitti">Alejandro Hitti</a> and <strong>Amazon</strong> for permitting us to reproduce this guide. You can find the original version on the <a href="https://developer.amazon.com/es/blogs/appstore/post/acefafad-29ba-4f31-8dae-00805fda3f58/intro-to-shaders-and-surfaces-with-gamemaker-studio-2">Amazon Developer Blog</a>.</p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Additional_Information.htm">Additional Information</a></div>
-        <div style="float:right">Next: <a href="Guide_To_Primitives_And_Vertex_Building.htm">Guide To Primitives And Vertex Building</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Additional_Information.htm">Additional Information</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="Guide_To_Primitives_And_Vertex_Building.htm">Guide To Primitives And Vertex Building</a></div>
       </div>
     </div>
     <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>

--- a/Manual/contents/Additional_Information/Guide_To_Using_Shaders.htm
+++ b/Manual/contents/Additional_Information/Guide_To_Using_Shaders.htm
@@ -33,7 +33,7 @@
     <li><strong>Uniform</strong>: These are variables that change per object and are passed by the user to the shader. These can be used in both the vertex and fragment shaders, but are read-only.</li>
   </ul>
   <p>You&#39;ll also see the use of <strong>vec</strong> as a keyword. This is used to identify a vector variable in the shader and you&#39;ll soon see that vectors are very important when working with shaders. That is why they are implemented as a base type in GLSL. If you are unfamiliar with them, they are a mathematical term represented as a matrix with only one column. In programming, we usually represent them as an array where the number of components corresponds to the dimension. Two and three-dimensional vectors are often used for positions, texture coordinates, or colors without an alpha channel, while four-dimensional ones are used for colors with an alpha channel. We can also specify if they hold booleans, integers, or floating point values. The syntax to declare a vector is this:</p>
-  <p class="code">vec2 firstVec;  // Two-dimensional vector of floats<br />
+  <p class="code language-glsl">vec2 firstVec;  // Two-dimensional vector of floats<br />
     vec3 secondVec; // Three-dimensional vector of floats<br />
     vec4 thirdVec;  // Four-dimensional vector of floats<br />
     <br />
@@ -41,43 +41,43 @@
     ivec4 intVec;   // Four-dimensional vector of integers
   </p>
   <p>To initialize them, we can use the constructor to create the vector. You need to provide the same number of values as the length of the vector, but you can mix and match scalars and smaller vectors to reach the target length. Here are some examples of this:</p>
-  <p class="code">// Simple 2D vector with 2 scalar values<br />
+  <p class="code language-glsl">// Simple 2D vector with 2 scalar values<br />
     vec2 firstVec  = vec2(2.0, 1.0);<br />
     // A 4D vector using 2 scalars and a vec2 create the 4 values<br />
     vec4 secondVec = vec4(1.0, firstVec, 0.0);<br />
     // A 3D vector using 1 component of a vec4 plus a vec2 to create the 3 values<br />
     vec3 thirdVec  = vec3(secondVec.x, firstVec);</p>
   <p>We can also assign them another vector of the same length (or <em>swizzle </em>the vector until it has the proper length, but we&#39;ll explain that in a moment):</p>
-  <p class="code">vec4 firstVec = vec4(0.0, 1.0, 2.0, 3.0);<br />
+  <p class="code language-glsl">vec4 firstVec = vec4(0.0, 1.0, 2.0, 3.0);<br />
     vec4 secondVec = firstVec;<br />
     vec3 thirdVec  = secondVec.xyz;<br />
     vec2 fourthVec = thirdVec.zx;</p>
   <p>When accessing vector components in GLSL, we have a few options. The most basic one is to treat the vector as an array and access the components using square brackets, like this:</p>
-  <p class="code">vec4 myVec;<br />
+  <p class="code language-glsl">vec4 myVec;<br />
     myVec[0] = 0.0;<br />
     myVec[1] = 1.0;<br />
     myVec[2] = 2.0;<br />
     myVec[3] = 3.0;</p>
   <p>However, there is another way to access the components with the following syntax:</p>
-  <p class="code">vec4 myVec;<br />
+  <p class="code language-glsl">vec4 myVec;<br />
     myVec.x = 0.0;<br />
     myVec.y = 1.0;</p>
   <p>This uses the component names inside the vector to access them. You can use x, y, z, or w, to get the first, second, third, or fourth components, respectively. We refer to this method as <strong>swizzling </strong>because the following syntax is also valid:</p>
-  <p class="code">vec4 firstVec;<br />
+  <p class="code language-glsl">vec4 firstVec;<br />
     vec3 secondVec = firstVec.xyz;<br />
     vec2 thirdVec  = secondVec.zy;<br />
     vec4 fourthVec = thirdVec.yxxy;</p>
   <p>As you can see, we can use any combination of up to four letters to create a vector of that length. We cannot attempt to access a component that would be out of bounds (for example, trying to access w in <span class="inline">secondVec</span> or <span class="inline">thirdVec</span>, since they don’t have a fourth component). Also, we can repeat letters and use them in any order, as long as the vector variable it’s being assigned to is the same size as the number of letters used.</p>
   <p>For obvious reasons, when using swizzle to set component values, you can’t use the same component twice. For example, the below is not valid as you are trying to set the same component to two different values:</p>
-  <p class="code">myVec.xx = vec2(2.0, 3.0);</p>
+  <p class="code language-glsl">myVec.xx = vec2(2.0, 3.0);</p>
   <p>Last, we have been using <span class="inline">xyzw</span> as our swizzle mask, which is usually the case when dealing with positions. There are two more sets of masks you can use: <span class="inline">rgba</span> (used for colors), or <span class="inline">stpq</span> (used for texture coordinates). Internally, there is no difference between these masks, and we only use them to make the code clearer as to what the vector represents in that instance. Also, we can’t combine swizzle masks in the same operation, so this is invalid:</p>
-  <p class="code"><span class="inline"></span>myVec = otherVec.ybp;</p>
+  <p class="code language-glsl"><span class="inline"></span>myVec = otherVec.ybp;</p>
   <p>Those were a lot of definitions and information, but knowing these things is necessary to understand shaders themselves.</p>
   <p> </p>
   <h2>Creating A Shader</h2>
   <p>When you create a shader in <span data-keyref="GameMaker Name">GameMaker</span>, it will open two files for you: a vertex shader (<span class="inline">.vsh</span>) and a fragment shader (<span class="inline">.fsh</span>). This is the most basic shader you can make, which takes a sprite, reads the texture, and colors each pixel with that color. If you specify vertex colors when drawing, those colors will blend with the texture.</p>
   <p>Let’s go through the code for a newly created shader asset and analyze it, starting with the vertex shader.</p>
-  <p class="code">// Passthrough Vertex Shader<br />
+  <p class="code language-glsl">// Passthrough Vertex Shader<br />
     attribute vec3 in_Position;                  // (x,y,z)<br />
     //attribute vec3 in_Normal;                  // (x,y,z)     unused in this shader.<br />
     attribute vec4 in_Colour;                    // (r,g,b,a)<br />
@@ -103,7 +103,7 @@
   </ul>
   <p>This shader should be left alone if you are not planning to play with vertex positions and it will not be used in any of the examples given below because all the effects shown will be created using the fragment shader.</p>
   <p>Let’s take a quick look at the fragment shader now:</p>
-  <p class="code">// Passthrough Fragment Shader<br />
+  <p class="code language-glsl">// Passthrough Fragment Shader<br />
     varying vec2 v_vTexcoord;<br />
     varying vec4 v_vColour;<br />
     <br />
@@ -124,7 +124,7 @@
   <p><a class="dropspot" data-rhwidget="DropSpot" data-target="drop-down" href="#">Colour Overlay Shader</a></p>
   <div class="droptext" data-targetname="drop-down">
     <p class="dropspot">We can edit the base shader now to do something different. We&#39;ll not be touching the vertex shader part, and only editing the fragment shader, and to start with we&#39;ll do a very simple operation, which is to make the shader draw the sprite using the colour red. We&#39;ll do this by simply changing the <span class="inline">gl_FragColor</span> to be red., like this:</p>
-    <p class="code">// Color Overlay Fragment Shader<br />
+    <p class="code language-glsl">// Color Overlay Fragment Shader<br />
       void main()<br />
       {<br />
           gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);<br />
@@ -134,7 +134,7 @@
     <p class="note"><span data-conref="../assets/snippets/Tag_note.hts"> </span> In the image above, the rectangle changes size because the base sprite has had the &quot;empty&quot; space around it cropped automatically when it was placed on the texture page by GameMaker, so each animation frame the triangles that make it up are different sizes to fit the cropped size of the frame. If you disable this option, then you&#39;d simply have a motionless red square on the screen.</p>
     <p class="dropspot">Above we mentioned the <span class="inline">texture2D</span> function, and we&#39;ll use that to grab the color at the pixel we are working on and get the transparency from it. The return value of is <span class="inline">texture2D</span> is a <span class="inline">vec4</span>, where the components are the red, green, blue, and alpha, in that order. We can access the alpha channel either by putting a period followed by an <span class="inline">a</span> or a <span class="inline">w</span> after the variable name. This corresponds to RGBA and XYZW, respectively.</p>
     <p class="dropspot">Here’s the updated code:</p>
-    <p class="code">// Color Overlay Fragment Shader<br />
+    <p class="code language-glsl">// Color Overlay Fragment Shader<br />
       varying vec2 v_vTexcoord;<br />
       <br />
       void main()<br />
@@ -157,7 +157,7 @@
       draw_self();<br />
       shader_reset();</p>
     <p class="dropspot">It’s the same code as before, but before we draw anything, we need to pass all the uniform values to the shader. In this case, we are passing the color as an array of floats. As for the shader, we will change it to include the uniform and use it, so it becomes:</p>
-    <p class="code">// Color Overlay Fragment Shader<br />
+    <p class="code language-glsl">// Color Overlay Fragment Shader<br />
       varying vec2 v_vTexcoord;<br />
       uniform vec4 u_colour;<br />
       void main()<br />
@@ -173,7 +173,7 @@
   <div class="droptext" data-targetname="drop-down1">
     <p class="dropspot">Making a black and white shader is a great way to learn more about how shaders work, and a lot of beginners start by trying to do this, since conceptually it&#39;s quite simple: get every pixel and assign it a shade of gray. But is it simple? Not quite...</p>
     <p class="dropspot">When using RGB colour, if all three components are the same value, then we get a gray tone. The naïve approach to creating a shader to use this idea would be to add all three color channels (red, green, and blue) and then divide it by three. After that you&#39;d assigned the value to all three channels, thus creating a gray tone. Here’s what that fragment shader looks like:</p>
-    <p class="code">// Black and white fragment shader<br />
+    <p class="code language-glsl">// Black and white fragment shader<br />
       varying vec2 v_vTexcoord;<br />
       varying vec4 v_vColour;<br />
       <br />
@@ -192,7 +192,7 @@
       shader_reset();</p>
     <p class="dropspot">Let’s compile and see what we got.</p>
     <p class="dropspot"><img alt="Black And White Shader" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_BlackAndWhite.gif" />This looks great already, right? Well, yes and no... there is a solution that is more “correct”, since instead of adding the components and dividing by three, we multiply each component by the standard NTSC values for black and white. Here’s the modified fragment shader code:</p>
-    <p class="code">// Black and white fragment shader<br />
+    <p class="code language-glsl">// Black and white fragment shader<br />
       varying vec2 v_vTexcoord;<br />
       <br />
       void main()<br />
@@ -203,7 +203,7 @@
       }
     </p>
     <p class="dropspot">We use the dot product as a shorthand for multiplying each component of <span class="inline">texColor</span> with the correct weights and then add them together. If you are unfamiliar with the dot product, this is essentially what’s happening:</p>
-    <p class="code">float gray = (texColor.r * 0.299) + (texColor.g * 0.587) + (texColor.b * 0.114);</p>
+    <p class="code language-glsl">float gray = (texColor.r * 0.299) + (texColor.g * 0.587) + (texColor.b * 0.114);</p>
     <p class="dropspot">In the end, it looks very similar, but it’s technically more correct.</p>
     <p class="dropspot"><img alt="Corrected Black And White Shader" class="center" src="../assets/Images/Scripting_Reference/Additional_Information/Shader_BlackAndWhite_Improved.gif" /></p>
     <p class="dropspot"> </p>
@@ -213,7 +213,7 @@
     <p class="dropspot">Our final shader example is a fun one and can be used to add life to text and buttons and other things. We&#39;ll start simple and add functionality gradually since this shader is highly customizable. There&#39;s quite a lot to cover for this one, so if you feel a bit lost or confused, please go back and re-read some of the sections above.</p>
     <p class="dropspot">The first thing we want to do is color pixels with every hue, depending on the pixel’s horizontal position. The way to do this is to set the x position to be the hue and then convert from HSV (hue, saturation, brightness) format to RGB (red, green, and blue) format. For this, we will need to write a helper function in our fragment shader that takes HSV values and returns an RGB vector. We will use a single function which does this without the need for any <span class="inline">if</span> statements, as using conditionals in shader code makes shaders <em>very </em>slow, and should be avoided.</p>
     <p class="dropspot">Here’s what the shader looks like at this stage:</p>
-    <p class="code">// Fragment Shader<br />
+    <p class="code language-glsl">// Fragment Shader<br />
       varying vec2 v_vTexcoord;<br />
       varying vec4 v_vColour;<br />
       <br />
@@ -243,14 +243,14 @@
     <p class="code">// Create Event<br />
       _uniUV = shader_get_uniform(shdrRainbow, &quot;u_uv&quot;);</p>
     <p class="dropspot">And we modify the draw event to get the values and then pass them to the shader:</p>
-    <p class="code">// Draw Event<br />
+    <p class="code language-glsl">// Draw Event<br />
       shader_set(shdrRainbow);<br />
       var uv = sprite_get_uvs(sprite_index, image_index);<br />
       shader_set_uniform_f(_uniUV, uv[0], uv[2]);<br />
       draw_self();<br />
       shader_reset();</p>
     <p class="dropspot">The function <a href="../GameMaker_Language/GML_Reference/Asset_Management/Sprites/Sprite_Information/sprite_get_uvs.htm"><span class="inline">sprite_get_uvs()</span></a> takes a sprite and an index, and it returns an array with tons of information, such as the coordinates for each corner, how many pixels were cropped to optimize it, etc. We are interested in two of those values: the left and right coordinates of the sprite, which are stored in <span class="inline">uv[0]</span> and <span class="inline">uv[2]</span> respectively. In the fragment shader, we will use those values now to calculate the normalized horizontal position like this:</p>
-    <p class="code">// Fragment Shader<br />
+    <p class="code language-glsl">// Fragment Shader<br />
       varying vec2 v_vTexcoord;<br />
       varying vec4 v_vColour;<br />
       <br />
@@ -294,7 +294,7 @@
       draw_self();<br />
       shader_reset();</p>
     <p class="dropspot">Finally, we&#39;ll go back to our shader to actually use these variables now. What we will do is multiply the speed with the time and add it to the position, like so:</p>
-    <p class="code">// Fragment Shader<br />
+    <p class="code language-glsl">// Fragment Shader<br />
       varying vec2 v_vTexcoord;<br />
       varying vec4 v_vColour;<br />
       <br />
@@ -349,7 +349,7 @@
       draw_self();<br />
       shader_reset();</p>
     <p class="dropspot">As for the shader, we need to pass the saturation and brightness to the color, which will affect the color generated by our helper function. The section needs to be multiplied by our position to reduce the range. We will also grab the entire texture color, so we can calculate our final color by mixing the texture color with the RGB conversion of our color. The last parameter of the mix function determines how much of the second color we want to add. This is our final shader code:</p>
-    <p class="code">// Fragment Shader<br />
+    <p class="code language-glsl">// Fragment Shader<br />
       varying vec2 v_vTexcoord;<br />
       varying vec4 v_vColour;<br />
       <br />

--- a/Manual/contents/Content.htm
+++ b/Manual/contents/Content.htm
@@ -12,6 +12,7 @@
   <meta name="search-keywords" content="" />
   <meta name="robots" content="NOODP" />
   <script src="assets/scripts/gml.js" type="module"></script>
+  <script src="assets/scripts/glsl.js" type="module"></script>
   <script src="assets/scripts/main_script.js" type="module"></script>
   <meta name="description" content="Find the answer to even the most obscure GameMaker questions in the GameMaker Manual, covering everything from rooms and particles to vectors and blend modes." />
   <meta property="og:description" content="Find the answer to even the most obscure GameMaker questions in the GameMaker Manual, covering everything from rooms and particles to vectors and blend modes." />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Emitters/audio_emitter_free.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Emitters/audio_emitter_free.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>audio_emitter_free</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../../../assets/css/default.css" type="text/css" />
   <script src="../../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -15,7 +15,9 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">audio_emitter_free</span></h1>
-  <p>With this function you can remove the given emitter from memory. This should always be done whenever the emitter is not going to be used further in the room or the game, ie: in the <a href="../../../../../The_Asset_Editors/Object_Properties/Object_Events.htm">Destroy Event</a> of the instance or in the <a href="../../../../../The_Asset_Editors/Object_Properties/Other_Events.htm">Room End Event</a>, otherwise you may end up with a memory leak that will slow down and eventually crash your game.</p>
+  <p>With this function you can remove the given emitter from memory. This should always be done whenever the emitter is not going to be used further in the room or the game, i.e.: in the <a href="../../../../../The_Asset_Editors/Object_Properties/Object_Events.htm">Clean Up Event</a> of the instance or in the <a href="../../../../../The_Asset_Editors/Object_Properties/Other_Events.htm">Room End Event</a>, otherwise you may end up with a memory leak that will slow down and eventually crash your game.</p>
+  <p>Sound instances currently being played on the emitter are force-stopped.</p>
+  <div data-conref="../../../../../assets/snippets/Note_Function_Triggers_Audio_Playback_Ended.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">audio_emitter_free</span>(emitter)</p>
@@ -28,7 +30,7 @@
       </tr>
       <tr>
         <td>emitter</td>
-        <td><span data-keyref="Type_ID_Audio_Emitter">Audio Emitter ID</span></td>
+        <td><span data-keyref="Type_ID_Audio_Emitter"><a href="audio_emitter_create.htm" target="_blank">Audio Emitter ID</a></span></td>
         <td>The index of the emitter to free.</td>
       </tr>
     </tbody>
@@ -38,12 +40,12 @@
   <p class="code"><span data-keyref="Type_Void">N/A</span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code">if (lives == 0) <br />
+  <p class="code">if (lives == 0)<br />
     {<br />
         audio_emitter_free(s_emit);<br />
-        room_goto(rm_Menu);<br />
+        room_goto(rm_menu);<br />
     }</p>
-  <p>The above code checks the value of the global variable &quot;lives&quot; and if it returns 0, it will destroy the emitter indexed in the variable &quot;s_emit&quot; and then go to the room indexed in the variable &quot;rm_Menu&quot;.</p>
+  <p>The above code checks the value of the global variable &quot;lives&quot; and if it returns 0, it will destroy the emitter indexed in the variable &quot;s_emit&quot; and then go to the room indexed in the variable &quot;rm_menu&quot;.</p>
   <p> </p>
   <p> </p>
   <p> </p>
@@ -54,7 +56,7 @@
         <div style="float:right">Next: <a href="audio_play_sound_on.htm">audio_play_sound_on</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 audio_emitter_free

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/room_get_info.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/room_get_info.htm
@@ -45,13 +45,12 @@
         ]<br />
     }</p>
   <p> </p>
-  <p>Note that the <span class="inline2">instances</span> and <span class="inline2">layers</span> members hold a value of 0 if the room has no instances or layers respectively.</p>
-  <p>If you call this function on a persistent room that you&#39;re not currently in, the <span class="inline2">instances</span> array will contain that room&#39;s currently active instances, which includes the persistent instances that still exist in the current room. The <span class="inline2">layers</span> array, on the other hand, contains all instances, including the non-persistent ones. Non-persistent instances aren&#39;t active at the time of calling <span class="inline3_func"><span data-field="title" data-format="default">room_get_info</span></span> from a different room but will be there when you return to the target room.</p>
+  <p>The <span class="inline2">instances</span> array holds the information from storage (including instances added to a room at runtime using <span class="inline3_func"><a data-xref="{title}" href="room_instance_add.htm">room_instance_add</a></span>). The <span class="inline2">layers</span> array holds the current instances in the room (the &quot;live&quot; state). Note that the <span class="inline2">instances</span> and <span class="inline2">layers</span> members hold a value of 0 if the room has no instances or layers respectively.</p>
   <p>The tables below list all the possible structs that can be contained in the returned struct:</p>
   <p><a class="dropspot" data-rhwidget="DropSpot" data-target="drop-down1" href="#">Room Info</a></p>
   <div class="droptext" data-targetname="drop-down1">
     <p class="dropspot">This is the main struct returned by the function. All variables listed below are present at the root of this returned struct:</p>
-    <table style="caption-side: top" class=" cke_show_border">
+    <table style="caption-side: top">
       <caption>Room Info Struct</caption>
       <colgroup>
         <col style="width:33.33%" />
@@ -66,77 +65,77 @@
         </tr>
         <tr>
           <td><span class="inline">width</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The width of the room</td>
         </tr>
         <tr>
           <td><span class="inline">height</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The height of the room</td>
         </tr>
         <tr>
           <td><span class="inline">creationCode</span></td>
-          <td><span data-keyref="Type_Function_Script"><a target="_blank" href="../../../GML_Overview/Script_Functions.htm">Script Function</a></span></td>
+          <td><span data-keyref="Type_Function_Script"><a href="../../../GML_Overview/Script_Functions.htm" target="_blank">Script Function</a></span></td>
           <td>The index of the script function that contains this room&#39;s creation code</td>
         </tr>
         <tr>
           <td><span class="inline">physicsWorld</span></td>
-          <td><span data-keyref="Type_Bool"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Boolean</a></span></td>
+          <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
           <td>Whether the room has a <a href="../../Physics/The_Physics_World/The_Physics_World.htm">physics world</a></td>
         </tr>
         <tr>
           <td><span class="inline">physicsGravityX</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The physics world&#39;s gravity component along the x axis</td>
         </tr>
         <tr>
           <td><span class="inline">physicsGravityY</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The physics world&#39;s gravity component along the y axis</td>
         </tr>
         <tr>
           <td><span class="inline">physicsPixToMeters</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The physics world&#39;s pixel-to-metre scale</td>
         </tr>
         <tr>
           <td><span class="inline">persistent</span></td>
-          <td><span data-keyref="Type_Bool"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Boolean</a></span></td>
+          <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
           <td>Whether the room is persistent</td>
         </tr>
         <tr>
           <td><span class="inline">enableViews</span></td>
-          <td><span data-keyref="Type_Bool"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Boolean</a></span></td>
+          <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
           <td>Whether views are enabled for the room</td>
         </tr>
         <tr>
           <td><span class="inline">clearDisplayBuffer</span></td>
-          <td><span data-keyref="Type_Bool"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Boolean</a></span></td>
+          <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
           <td>Whether to clear the display buffer before drawing the room</td>
         </tr>
         <tr>
           <td><span class="inline">clearViewportBackground</span></td>
-          <td><span data-keyref="Type_Bool"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Boolean</a></span></td>
+          <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
           <td>Whether to clear viewports&#39; backgrounds before drawing to them</td>
         </tr>
         <tr>
           <td><span class="inline">colour</span></td>
-          <td><span data-keyref="Type_Constant_Colour"><a target="_blank" href="../../Drawing/Colour_And_Alpha/Colour_And_Alpha.htm">Colour</a></span></td>
+          <td><span data-keyref="Type_Constant_Colour"><a href="../../Drawing/Colour_And_Alpha/Colour_And_Alpha.htm" target="_blank">Colour</a></span></td>
           <td>The clear colour used when <span class="inline2">clearDisplayBuffer</span> is set to <span class="inline2">true</span></td>
         </tr>
         <tr>
           <td><span class="inline">instances</span></td>
-          <td><span data-keyref="Type_Array"><a target="_blank" href="../../../GML_Overview/Arrays.htm">Array</a></span> of <span data-keyref="Type_Struct_Room_Instance_Info"><a target="_blank" href="room_get_info.htm#room_instance_info_struct">Room Instance Info Struct</a></span></td>
+          <td><span data-keyref="Type_Array"><a href="../../../GML_Overview/Arrays.htm" target="_blank">Array</a></span> of <span data-keyref="Type_Struct_Room_Instance_Info"><a href="room_get_info.htm#room_instance_info_struct" target="_blank">Room Instance Info Struct</a></span></td>
           <td>An array listing all instances placed in the room with basic information on them</td>
         </tr>
         <tr>
           <td><span class="inline">layers</span></td>
-          <td><span data-keyref="Type_Array"><a target="_blank" href="../../../GML_Overview/Arrays.htm">Array</a></span> of <span data-keyref="Type_Struct_Room_Layer_Info"><a target="_blank" href="room_get_info.htm#room_layer_info_struct">Room Layer Info Struct</a></span></td>
+          <td><span data-keyref="Type_Array"><a href="../../../GML_Overview/Arrays.htm" target="_blank">Array</a></span> of <span data-keyref="Type_Struct_Room_Layer_Info"><a href="room_get_info.htm#room_layer_info_struct" target="_blank">Room Layer Info Struct</a></span></td>
           <td>An array listing all room layers, in order of increasing depth</td>
         </tr>
         <tr>
           <td><span class="inline">views</span></td>
-          <td><span data-keyref="Type_Array"><a target="_blank" href="../../../GML_Overview/Arrays.htm">Array</a></span> of <span data-keyref="Type_Struct_Room_View_Info"><a target="_blank" href="room_get_info.htm#room_view_info_struct">Room View Info Struct</a></span></td>
+          <td><span data-keyref="Type_Array"><a href="../../../GML_Overview/Arrays.htm" target="_blank">Array</a></span> of <span data-keyref="Type_Struct_Room_View_Info"><a href="room_get_info.htm#room_view_info_struct" target="_blank">Room View Info Struct</a></span></td>
           <td>An array listing all views, ordered by view index</td>
         </tr>
       </tbody>
@@ -146,7 +145,7 @@
   <div class="droptext" data-targetname="drop-down2">
     <p class="dropspot">This type of struct represents one instance in the room.</p>
     <p class="dropspot">These structs are found in the <span class="inline2">instances</span> array, which is part of the main struct returned by the function.</p>
-    <table style="caption-side: top" class=" cke_show_border">
+    <table style="caption-side: top">
       <caption>Instance Info Struct</caption>
       <colgroup>
         <col style="width:33.33%" />
@@ -161,62 +160,62 @@
         </tr>
         <tr>
           <td><span class="inline">id</span></td>
-          <td><span data-keyref="Type_ID_Instance"><a target="_blank" href="../Instances/Instance_Variables/id.htm">Object Instance</a></span></td>
+          <td><span data-keyref="Type_ID_Instance"><a href="../Instances/Instance_Variables/id.htm" target="_blank">Object Instance</a></span></td>
           <td>The instance ID</td>
         </tr>
         <tr>
           <td><span class="inline">object_index</span></td>
-          <td><span data-keyref="Type_String"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">String</a></span></td>
+          <td><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
           <td>The name of the object this is an instance of (use <span class="inline3_func"><a data-xref="{title}" href="../Assets_And_Tags/asset_get_index.htm">asset_get_index</a></span> to get the actual object)</td>
         </tr>
         <tr>
           <td><span class="inline">x</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The x coordinate of the instance&#39;s position</td>
         </tr>
         <tr>
           <td><span class="inline">y</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The y coordinate of the instance&#39;s position</td>
         </tr>
         <tr>
           <td><span class="inline">xscale</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The x scale of the instance</td>
         </tr>
         <tr>
           <td><span class="inline">yscale</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The y scale of the instance</td>
         </tr>
         <tr>
           <td><span class="inline">angle</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The rotation angle of the instance</td>
         </tr>
         <tr>
           <td><span class="inline">image_index</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The image index used by the instance</td>
         </tr>
         <tr>
           <td><span class="inline">image_speed</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The image speed of the instance</td>
         </tr>
         <tr>
           <td><span class="inline">colour</span></td>
-          <td><span data-keyref="Type_Constant_Colour"><a target="_blank" href="../../Drawing/Colour_And_Alpha/Colour_And_Alpha.htm">Colour</a></span></td>
+          <td><span data-keyref="Type_Constant_Colour"><a href="../../Drawing/Colour_And_Alpha/Colour_And_Alpha.htm" target="_blank">Colour</a></span></td>
           <td>The blend colour used to draw the instance</td>
         </tr>
         <tr>
           <td><span class="inline">creation_code</span></td>
-          <td><span data-keyref="Type_Function_Script"><a target="_blank" href="../../../GML_Overview/Script_Functions.htm">Script Function</a></span></td>
+          <td><span data-keyref="Type_Function_Script"><a href="../../../GML_Overview/Script_Functions.htm" target="_blank">Script Function</a></span></td>
           <td>The index of the script function that contains the instance&#39;s creation code</td>
         </tr>
         <tr>
           <td><span class="inline">pre_creation_code</span></td>
-          <td><span data-keyref="Type_Function_Script"><a target="_blank" href="../../../GML_Overview/Script_Functions.htm">Script Function</a></span></td>
+          <td><span data-keyref="Type_Function_Script"><a href="../../../GML_Overview/Script_Functions.htm" target="_blank">Script Function</a></span></td>
           <td>The index of the script function that holds the pre-creation code for this specific instance, i.e. the overrides for its <a data-xref="{title}" href="../../../../The_Asset_Editors/Object_Properties/Object_Variables.htm">Object Variables</a> as set in the Room Editor. See: <a data-xref="{text}" href="../../../../The_Asset_Editors/Object_Properties/Object_Variables.htm#h">Pre-creation Code</a></td>
         </tr>
       </tbody>
@@ -226,7 +225,7 @@
   <div class="droptext" data-targetname="drop-down3">
     <p class="dropspot">This type of struct represents one layer in the room.</p>
     <p class="dropspot">These structs are found in the <span class="inline2">layers</span> array, which is part of the main struct returned by the function.</p>
-    <table style="caption-side: top" class=" cke_show_border">
+    <table style="caption-side: top">
       <caption>Layer Info Struct</caption>
       <colgroup>
         <col style="width:33.33%" />
@@ -241,67 +240,67 @@
         </tr>
         <tr>
           <td><span class="inline">id</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The layer handle</td>
         </tr>
         <tr>
           <td><span class="inline">name</span></td>
-          <td><span data-keyref="Type_String"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">String</a></span></td>
+          <td><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
           <td>The name of the layer</td>
         </tr>
         <tr>
           <td><span class="inline">visible</span></td>
-          <td><span data-keyref="Type_Bool"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Boolean</a></span></td>
+          <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
           <td>Whether the layer is visible</td>
         </tr>
         <tr>
           <td><span class="inline">depth</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The depth of the layer</td>
         </tr>
         <tr>
           <td><span class="inline">xoffset</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The x offset of the layer</td>
         </tr>
         <tr>
           <td><span class="inline">yoffset</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The y offset of the layer</td>
         </tr>
         <tr>
           <td><span class="inline">hspeed</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The horizontal speed of the layer</td>
         </tr>
         <tr>
           <td><span class="inline">vspeed</span></td>
-          <td><span data-keyref="Type_Real"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Real</a></span></td>
+          <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
           <td>The vertical speed of the layer</td>
         </tr>
         <tr>
           <td><span class="inline">effectEnabled</span></td>
-          <td><span data-keyref="Type_Bool"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Boolean</a></span></td>
+          <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
           <td>Whether the layer filter/effect is currently enabled</td>
         </tr>
         <tr>
           <td><span class="inline">effectToBeEnabled</span></td>
-          <td><span data-keyref="Type_Bool"><a target="_blank" href="../../../GML_Overview/Data_Types.htm">Boolean</a></span></td>
+          <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
           <td>Whether the layer filter/effect should be enabled/disabled in the next frame (the next value of <span class="inline2">effectEnabled</span>)</td>
         </tr>
         <tr>
           <td><span class="inline">effect</span></td>
-          <td><span data-keyref="Type_Struct_FX"><a target="_blank" href="Filter_Effect_Layers/fx_create.htm">FX Struct</a></span></td>
+          <td><span data-keyref="Type_Struct_FX"><a href="Filter_Effect_Layers/fx_create.htm" target="_blank">FX Struct</a></span></td>
           <td>A struct containing the effect&#39;s parameters (-1 if no layer effect is set)</td>
         </tr>
         <tr>
           <td><span class="inline">shaderID</span></td>
-          <td><span data-keyref="Type_Asset_Shader"><a target="_blank" href="../../../../The_Asset_Editors/Shaders.htm">Shader Asset</a></span></td>
+          <td><span data-keyref="Type_Asset_Shader"><a href="../../../../The_Asset_Editors/Shaders.htm" target="_blank">Shader Asset</a></span></td>
           <td>The shader to be applied to the layer (<span class="inline3_func"><a data-xref="{title}" href="General_Layer_Functions/layer_shader.htm">layer_shader</a></span>)</td>
         </tr>
         <tr>
           <td><span class="inline">elements</span></td>
-          <td><span data-keyref="Type_Array"><a target="_blank" href="../../../GML_Overview/Arrays.htm">Array</a></span> of <span data-keyref="Type_Struct_Room_Layer_Element_Info"><a target="_blank" href="room_get_info.htm#room_layer_element_info_struct">Room Layer Element Info Struct</a></span></td>
+          <td><span data-keyref="Type_Array"><a href="../../../GML_Overview/Arrays.htm" target="_blank">Array</a></span> of <span data-keyref="Type_Struct_Room_Layer_Element_Info"><a href="room_get_info.htm#room_layer_element_info_struct" target="_blank">Room Layer Element Info Struct</a></span></td>
           <td>An array listing all elements on the layer. Each element type struct contains information specific to it.</td>
         </tr>
       </tbody>
@@ -869,19 +868,18 @@
     persistent = true;<br />
     room_persistent = true;<br />
     <br />
-    room_goto(rom_two);
+    room_goto(rm_two);
   </p>
   <p class="code_heading">Room Start Event</p>
-  <p class="code">if (room != rom_two) { exit; }<br />
+  <p class="code">if (room != rm_two) { exit; }<br />
     <br />
-    var _info = <span data-field="title" data-format="default">room_get_info</span>(rom_one, false, true, true, true, false, true);<br />
+    var _info = <span data-field="title" data-format="default">room_get_info</span>(rm_one, false, true, true, true, false, true);<br />
     var _info_json = json_stringify(_info, true);<br />
     show_debug_message(_info_json);
   </p>
   <p>This code shows how to get live data on a persistent room you&#39;re not currently in.</p>
-  <p>In an object&#39;s Create event a new instance of an object not marked persistent is first added using <span class="inline3_func"><a data-xref="{title}" href="../Instances/instance_create_layer.htm">instance_create_layer</a></span>. The instance executing the code is then marked persistent by setting its <span class="inline2"><a data-xref="{title}" href="../Instances/Instance_Variables/persistent.htm">persistent</a></span> variable to <span class="inline2">true</span> and the room is also marked persistent by setting <span class="inline2"><a data-xref="{title}" href="room_persistent.htm">room_persistent</a></span> to <span class="inline2">true</span>. The room is then changed to a room <span class="inline2">rom_two</span> using <span class="inline3_func"><a data-xref="{title}" href="room_goto.htm">room_goto</a></span>.</p>
-  <p>In the Room Start event a check is first performed to find out if the current room is <span class="inline2">rom_two</span>. If it isn&#39;t, the event is exited. If code execution continues, the live data on <span class="inline2">instances</span>, <span class="inline2">layers</span> and <span class="inline2">layer_elements</span> in the original room is requested using a call to <span class="inline3_func"><span data-field="title" data-format="default">room_get_info</span></span>. This info is once again, like in the previous examples, output in a debug message.</p>
-  <p>Note that a layer element is present for both the calling instance and the instance created in the Create event, but only the calling instance is present in the <span class="inline2">instances</span> array because it marked itself as persistent and therefore is still active at the time of calling the function.</p>
+  <p>In an object&#39;s Create event a new instance of an object not marked persistent is first added using <span class="inline3_func"><a data-xref="{title}" href="../Instances/instance_create_layer.htm">instance_create_layer</a></span>. The instance executing the code is then marked persistent by setting its <span class="inline2"><a data-xref="{title}" href="../Instances/Instance_Variables/persistent.htm">persistent</a></span> variable to <span class="inline2">true</span> and the room is also marked persistent by setting <span class="inline2"><a data-xref="{title}" href="room_persistent.htm">room_persistent</a></span> to <span class="inline2">true</span>. The room is then changed to a room <span class="inline2">rm_two</span> using <span class="inline3_func"><a data-xref="{title}" href="room_goto.htm">room_goto</a></span>.</p>
+  <p>In the Room Start event a check is first performed to find out if the current room is <span class="inline2">rm_two</span>. If it isn&#39;t, the event is exited. If code execution continues, the live data on <span class="inline2">instances</span>, <span class="inline2">layers</span> and <span class="inline2">layer_elements</span> in the original room is requested using a call to <span class="inline3_func"><span data-field="title" data-format="default">room_get_info</span></span>. This info is once again, like in the previous examples, output in a debug message.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
@@ -891,7 +889,7 @@
         <div>Next: <a data-xref="{title}" href="room_goto.htm">room_goto</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 room_get_info

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_enable_corner_id.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_enable_corner_id.htm
@@ -19,8 +19,8 @@
   <p>It sets a global state for all shaders being used where, when enabled, the shader &quot;steals&quot; 2 bits from the input colour values; one from the lowest bit of the red colour value, and one from the lowest bit of the blue colour value. These values can then be recovered in the shader to work out which vertex you are dealing with (i.e. which corner).</p>
   <p class="note"><span data-conref="../../../../assets/snippets/Tag_note.hts"> </span> This will not work when using <a href="../../Drawing/Primitives/Primitives_And_Vertex_Formats.htm">vertex buffers and primitives</a> as the colour data for each vertex is handled by the user.</p>
   <p>The lowest bit of the <em>blue</em> component stores the <em>most significant bit</em>, the lowest bit of the <em>red</em> component stores the <em>least significant bit</em>. You can calculate the corner ID in a vertex shader by doing this:</p>
-  <pre data-stringify-type="pre">vec2 rem = mod(in_Colour.rb * 255., 2.);
-int corner_id = int(dot(vec2(1., 2.), rem));</pre>
+  <p class="code language-glsl">vec2 rem = mod(in_Colour.rb * 255., 2.);
+int corner_id = int(dot(vec2(1., 2.), rem));</p>
   <p>The following table lists the possible values and their corresponding corner position: </p>
   <table id="shader_corner_id" style="caption-side: top">
     <caption id="">Shader Corner ID</caption>
@@ -97,7 +97,7 @@ int corner_id = int(dot(vec2(1., 2.), rem));</pre>
         <div style="float:right">Next: <a data-xref="{title}" href="shader_get_name.htm">shader_get_name</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 shader_enable_corner_id

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_reset.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_reset.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>shader_reset</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../../assets/css/default.css" type="text/css" />
   <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -21,13 +21,13 @@
   <p class="code"><span data-field="title" data-format="default">shader_reset</span>()</p>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Void"></span></p>
+  <p class="code"><span data-keyref="Type_Void">N/A</span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">shader_set(shader_Glass);<br />
     draw_self();<br />
     shader_reset();</p>
-  <p>The above code will set a shader to be used for drawing, then draw the current sprite used for the instance using it. Finally it will reset the shader to revert to GameMaker&#39;s default shader.</p>
+  <p>The above code will set a shader to be used for drawing, then draw the current sprite used for the instance using it. Finally, it will reset the shader to revert to <span data-keyref="GameMaker Name">GameMaker</span>&#39;s default shader.</p>
   <p> </p>
   <p> </p>
   <p> </p>
@@ -38,7 +38,7 @@
         <div style="float:right">Next: <a href="shader_is_compiled.htm">shader_is_compiled</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 shader_reset

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_set_uniform_f.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_set_uniform_f.htm
@@ -18,7 +18,7 @@
   <p>With this function you can set the value (or values) of a shader constant.</p>
   <p>You must previously have gotten the &quot;handle&quot; of the constant using the function <span class="inline3_func"><a data-xref="{title}" href="shader_get_uniform.htm">shader_get_uniform</a></span>, and you will have to know what type of constant it is to pass the correct number of floating point values through to it, i.e.: if you have a <span class="inline2">vec2</span> you will need to pass two values to the function.</p>
   <p>An exception to the above rule is when dealing with 32bit colour values. You can pass into the shader up to eight 32bit colour values and they will automatically be converted for you into <span class="inline2">vec4</span> values of 0 - 1. However for this you <i>must</i> use the shader constant name <span class="inline2">in_Colour</span>, for a single colour, or <span class="inline2">in_Colour0</span>, <span class="inline2">in_Colour1</span>, etc. up to <span class="inline2">in_Colour7</span> for multiple input values. The following to examples show how this would look in the shader itself:</p>
-  <p class="code">    //Single colour<br />
+  <p class="code language-glsl">    //Single colour<br />
         attribute vec2 in_Position;<br />
         attribute vec4 in_Colour;<br />
         attribute vec2 in_TextureCoord;<br />
@@ -74,7 +74,7 @@
         <div style="float:right">Next: <a data-xref="{title}" href="shader_set_uniform_f_array.htm">shader_set_uniform_f_array</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 shader_set_uniform_f

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_set_uniform_matrix_array.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_set_uniform_matrix_array.htm
@@ -18,7 +18,7 @@
   <p>This function sets a shader constant to hold an array of matrix values.</p>
   <p>You must previously have gotten the &quot;handle&quot; of the constant using the function <span class="inline3_func"><a data-xref="{title}" href="shader_get_uniform.htm">shader_get_uniform</a></span>, and you will have to have previously initialised the array as an array of floating point values, where each successive group of 16 floats holds the contents of a 4x4 matrix.</p>
   <p>In the shader you&#39;d define the uniform as follows: </p>
-  <p class="code">uniform mat4 u_mTransforms[MAX_TRANSFORMS];</p>
+  <p class="code language-glsl">uniform mat4 u_mTransforms[MAX_TRANSFORMS];</p>
   <p>Every group of 16 floats in the array becomes directly accessible as an element of the uniform array, i.e. the first 16 array elements correspond to <span class="inline2">u_mTransforms[0]</span>, the next 16 elements to <span class="inline2">u_mTransforms[1]</span>, etc.</p>
   <p> </p>
   <div data-conref="../../../../assets/snippets/Note_Set_Uniforms_After_Shader_Set.hts"> </div>
@@ -76,7 +76,7 @@
         <div style="float:right">Next: <a data-xref="{title}" href="shader_reset.htm">shader_reset</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 shader_set_uniform_matrix_array

--- a/Manual/contents/GameMaker_Language/GML_Reference/Buffers/Buffers.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Buffers/Buffers.htm
@@ -117,11 +117,11 @@
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="../GML_Reference.htm">GML Reference</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="../GML_Reference.htm">GML Code Reference</a></div>
         <div style="float:right">Next: <a data-xref="{title}" href="../OS_And_Compiler/OS_And_Compiler.htm">OS And Compiler</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 Buffers

--- a/Manual/contents/GameMaker_Language/GML_Reference/Buffers/buffer_read.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Buffers/buffer_read.htm
@@ -21,7 +21,7 @@
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> You can use <span class="inline3_func"><a data-xref="{title}" href="buffer_peek.htm">buffer_peek</a></span> to get a value anywhere in the buffer without changing the seek position.</p>
   <p>The return value depends on the type of data that you are reading, which can be one of the following constants:</p>
   <div data-conref="../../../assets/snippets/buffer_data_type_constants.hts"> </div>
-  <p>If the function succeeds, it will return a value of the given type, however if it fails then it will cause a <a href="../../../Additional_Information/Errors/Runner_Errors.htm">runner error</a>.</p>
+  <p>If the function succeeds, it will return a value of the given type. If it fails, however, it will cause a <a href="../../../Additional_Information/Errors/Runner_Errors.htm">runner error</a>.</p>
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> Using the incorrect data type for the data being read will result in erroneous values being returned.</p>
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> Reading a <span class="inline2">buffer_s32</span> or <span class="inline2">buffer_u32</span> on HTML5 returns the value as a <span data-keyref="Type_Real"><a href="../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span>, which is a 64-bit double, as int32 is not supported on that platform.</p>
   <p> </p>
@@ -72,7 +72,7 @@
         <div style="float:right">Next: <a data-xref="{title}" href="buffer_write.htm">buffer_write</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 buffer_read

--- a/Manual/contents/GameMaker_Language/GML_Reference/Buffers/buffer_write.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Buffers/buffer_write.htm
@@ -99,7 +99,7 @@
         <div style="float:right">Next: <a data-xref="{title}" href="buffer_fill.htm">buffer_fill</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 buffer_write

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Surfaces/surface_get_texture_depth.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Surfaces/surface_get_texture_depth.htm
@@ -18,14 +18,14 @@
   <p>This function returns the depth texture of the given surface or -1 if no depth texture exists.</p>
   <p>The texture can then be passed to <span class="inline3_func"><a data-xref="{title}" href="../Textures/texture_set_stage.htm">texture_set_stage</a></span> for use in <a data-xref="{title}" href="../../Asset_Management/Shaders/Shaders.htm">Shaders</a>.</p>
   <p>The depth value is stored in the red channel and can be accessed in a shader as follows: </p>
-  <p class="code">float depth = texture2D(depth_texture, v_vTexcoord).r;</p>
+  <p class="code language-glsl">float depth = texture2D(depth_texture, v_vTexcoord).r;</p>
   <p>When you write to the depth buffer with a <a href="../../Maths_And_Numbers/Matrix_Functions/matrix_build_projection_perspective.htm" title="matrix_build_projection_perspective()">perspective</a> <a href="../../Maths_And_Numbers/Matrix_Functions/matrix_build_projection_perspective_fov.htm" title="matrix_build_projection_perspective_fov()">projection</a> set, the depth values stored in the texture will not be linear and you need to convert the values to linear ones in a custom shader, using the following shader function: </p>
   <div data-conref="../../../../assets/snippets/Code_Snippet_Shader_Linearize_Depth.hts"> </div>
   <p>In the shader you can then use this function as follows: </p>
   <p class="code_heading">Vertex Shader</p>
-  <p class="code">// Identical to passthrough vertex shader code</p>
+  <p class="code language-glsl">// Identical to passthrough vertex shader code</p>
   <p class="code_heading">Fragment Shader</p>
-  <p class="code">precision highp float; // This might be required on some platforms!<br />
+  <p class="code language-glsl">precision highp float; // This might be required on some platforms!<br />
     <br />
     varying vec2 v_vTexcoord;<br />
     <br />
@@ -117,7 +117,7 @@
         <div>Next: <a data-xref="{title}" href="surface_get_depth_disable.htm">surface_get_depth_disable</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 surface_get_texture_depth

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Textures/texturegroup_get_fonts.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Textures/texturegroup_get_fonts.htm
@@ -29,7 +29,7 @@
         <th>Description</th>
       </tr>
       <tr>
-        <td>tex</td>
+        <td>tex_id</td>
         <td><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td>The name of the texture group to check (a string)</td>
       </tr>
@@ -37,7 +37,7 @@
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Array"><a href="../../../GML_Overview/Arrays.htm" target="_blank">Array</a></span></p>
+  <p class="code"><span data-keyref="Type_Array"><a href="../../../GML_Overview/Arrays.htm" target="_blank">Array</a></span> of <span data-keyref="Type_Asset_Font"><a href="../../../../The_Asset_Editors/Fonts.htm" target="_blank">Font Asset</a></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">var _tex_array = texturegroup_get_fonts( &quot;MainMenu&quot;);<br />
@@ -51,11 +51,11 @@
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a data-xref="{title}" href="Textures.htm">Back</a></div>
-        <div style="float:right">Next: <a data-xref="{title}" href="texturegroup_get_tilesets.htm">Next</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Textures.htm">Textures</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="texturegroup_get_tilesets.htm">texturegroup_get_tilesets</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 texturegroup_get_fonts

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Textures/texturegroup_get_sprites.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Textures/texturegroup_get_sprites.htm
@@ -37,7 +37,7 @@
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Array"><a href="../../../GML_Overview/Arrays.htm" target="_blank">Array</a></span></p>
+  <p class="code"><span data-keyref="Type_Array"><a href="../../../GML_Overview/Arrays.htm" target="_blank">Array</a></span> of <span data-keyref="Type_Asset_Sprite"><a href="../../../../The_Asset_Editors/Sprites.htm" target="_blank">Sprite Asset</a></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">var _tex_array = texturegroup_get_sprites( &quot;MainMenu&quot;);<br />
@@ -51,11 +51,11 @@
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a data-xref="{title}" href="Textures.htm">Back</a></div>
-        <div style="float:right">Next: <a data-xref="{title}" href="texturegroup_get_fonts.htm">Next</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Textures.htm">Textures</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="texturegroup_get_fonts.htm">texturegroup_get_fonts</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 texturegroup_get_sprites

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Textures/texturegroup_get_tilesets.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Textures/texturegroup_get_tilesets.htm
@@ -29,7 +29,7 @@
         <th>Description</th>
       </tr>
       <tr>
-        <td>tex</td>
+        <td>tex_id</td>
         <td><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span></td>
         <td>The name of the texture group to check (a string)</td>
       </tr>
@@ -37,7 +37,7 @@
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Array"><a href="../../../GML_Overview/Arrays.htm" target="_blank">Array</a></span></p>
+  <p class="code"><span data-keyref="Type_Array"><a href="../../../GML_Overview/Arrays.htm" target="_blank">Array</a></span> of <span data-keyref="Type_Asset_Tile_Set"><a href="../../../../The_Asset_Editors/Tile_Sets.htm" target="_blank">Tile Set Asset</a></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">var _tex_array = texturegroup_get_tilesets( &quot;MainMenu&quot;);<br />
@@ -51,11 +51,11 @@
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a data-xref="{title}" href="Textures.htm">Back</a></div>
-        <div style="float:right">Next: <a data-xref="{title}" href="texturegroup_get_names.htm">Next</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Textures.htm">Textures</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="texturegroup_get_names.htm">texturegroup_get_names</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 texturegroup_get_tilesets

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Videos/video_open.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Videos/video_open.htm
@@ -16,7 +16,7 @@
   <meta name="condition-tags" content="" />
 </head>
 <body>
-  <h1 id="h">video_open</h1>
+  <h1><span data-field="title" data-format="default">video_open</span></h1>
   <p>This function opens a video file using the path specified. The path can refer to a file in the <a href="../../../../Settings/Included_Files.htm">Included Files</a> of your project, a file locally present on the user&#39;s device, a URL for loading a file from the internet (which may not work on all platforms), or a <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#constraints">constraints object</a> to display a camera feed as a video (only supported on GX.games).</p>
   <p>As you can only load one video at a time, this function loads the specified video into the only available &quot;video slot&quot;, which is then manipulated via the other <a href="Videos.htm">Video functions</a>.</p>
   <p>When passing a constraints object to show a video feed on GX.games you can also enable microphone audio.</p>
@@ -70,7 +70,7 @@
         <div>Next: <a data-xref="{title}" href="video_close.htm">video_close</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 video_open

--- a/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/cache_directory.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/cache_directory.htm
@@ -15,7 +15,7 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">cache_directory</span></h1>
-  <p>This function returns the cache directory for your game. Use this directory to store cached data that is not permanently needed for your game.<b></b></p>
+  <p>This variable holds the path to the cache directory for your game. Use this directory to store cached data that is not permanently needed for your game.<b></b></p>
   <p>On some consoles, certain options may need to be enabled for this to hold a valid path.</p>
   <div data-conref="../../../../assets/snippets/Note_Variable_Contains_Path_Including_Final_Slash.hts"> </div>
   <p> </p>
@@ -33,11 +33,11 @@
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="File_Directories.htm">File Directories</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="File_Directories.htm">File Directories</a></div>
         <div style="float:right">Next: <a data-xref="{title}" href="directory_exists.htm">directory_exists</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 cache_directory

--- a/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/program_directory.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/program_directory.htm
@@ -15,7 +15,7 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">program_directory</span></h1>
-  <p>This function returns the directory where the game&#39;s runner (executable) is stored. However, this may not always be useful, particularly as some devices run the executable from a *.zip file, so this would return that location no matter where the extracted executable is actually running from.</p>
+  <p>This variable holds the path to the directory where the game&#39;s runner (executable) is stored. However, this may not always be useful, particularly as some devices run the executable from a *.zip file, so this would return that location no matter where the extracted executable is actually running from.</p>
   <p>This is different from <span class="inline2"><a data-xref="{title}" href="working_directory.htm">working_directory</a></span>, which stores where the game&#39;s files are stored, however by default they are in the same location.</p>
   <div data-conref="../../../../assets/snippets/Note_Warning_GM_FileSystem_Sandboxed.hts"> </div>
   <div data-conref="../../../../assets/snippets/Warning_directory_os_permissions.hts"> </div>
@@ -39,7 +39,7 @@
         <div style="float:right">Next: <a data-xref="{title}" href="cache_directory.htm">cache_directory</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 program_directory

--- a/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/temp_directory.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/temp_directory.htm
@@ -15,7 +15,7 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">temp_directory</span></h1>
-  <p>This function returns the temporary directory created for your game each time it is run.</p>
+  <p>This variable holds the path to the temporary directory created for your game each time it is run.</p>
   <p>This directory will hold files and can be accessed while the game is running, but it will be removed (along with all files that it contains) when the game is closed.<b></b></p>
   <div data-conref="../../../../assets/snippets/Note_Variable_Contains_Path_Including_Final_Slash.hts"> </div>
   <p> </p>
@@ -33,11 +33,11 @@
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="File_Directories.htm">File Directories</a></div>
-        <div style="float:right">Next: <a href="working_directory.htm">working_directory</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="File_Directories.htm">File Directories</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="working_directory.htm">working_directory</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 temp_directory

--- a/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/working_directory.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/working_directory.htm
@@ -15,8 +15,8 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">working_directory</span></h1>
-  <p>This returns a path that points to where the game&#39;s files are stored.</p>
-  <p>In most cases, this is the same as the <span class="inline2"><a data-xref="{title}" href="program_directory.htm">program_directory</a></span>, which is the path to the game&#39;s runner (executable). However if the game&#39;s files happen to be in a different directory than the runner (say you use <span class="inline3_func"><a data-xref="{title}" href="../../General_Game_Control/game_change.htm">game_change</a></span> to use a different working directory or use command line to run a runner in a different location), then this will point to where the game files are, not the runner.</p>
+  <p>This variable holds the path that points to where the game&#39;s files are stored.</p>
+  <p>In most cases, this is the same as the <span class="inline2"><a data-xref="{title}" href="program_directory.htm">program_directory</a></span>, which is the path to the game&#39;s runner (executable). However, if the game&#39;s files happen to be in a different directory than the runner (say you use <span class="inline3_func"><a data-xref="{title}" href="../../General_Game_Control/game_change.htm">game_change</a></span> to use a different working directory or use command line to run a runner in a different location), then this will point to where the game files are, not the runner.</p>
   <p>It may also be a different directory when testing your project through the IDE, as then the game files and the runner are in different locations as well.</p>
   <p>When using this directory to write out a file, <span data-keyref="GameMaker Name">GameMaker</span> will redirect it to the <span class="inline2"><a data-xref="{title}" href="../../General_Game_Control/game_save_id.htm">game_save_id</a></span> location if the <a href="../../../../Additional_Information/The_File_System.htm">file system sandbox</a> does not allow writing to the working directory (this is the default behaviour, which can be disabled in the <a data-xref="{title}" href="../../../../Settings/Game_Options.htm">Game Options</a> for Desktop targets only).</p>
   <div data-conref="../../../../assets/snippets/Note_Warning_GM_FileSystem_Sandboxed.hts"> </div>
@@ -37,11 +37,11 @@
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="File_Directories.htm">File Directories</a></div>
-        <div style="float:right">Next: <a href="program_directory.htm">program_directory</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="File_Directories.htm">File Directories</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="program_directory.htm">program_directory</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 working_directory

--- a/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/working_directory.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/working_directory.htm
@@ -15,7 +15,7 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">working_directory</span></h1>
-  <p>This variable holds the path that points to where the game&#39;s files are stored.</p>
+  <p>This variable holds the path to the directory where the game&#39;s files are stored.</p>
   <p>In most cases, this is the same as the <span class="inline2"><a data-xref="{title}" href="program_directory.htm">program_directory</a></span>, which is the path to the game&#39;s runner (executable). However, if the game&#39;s files happen to be in a different directory than the runner (say you use <span class="inline3_func"><a data-xref="{title}" href="../../General_Game_Control/game_change.htm">game_change</a></span> to use a different working directory or use command line to run a runner in a different location), then this will point to where the game files are, not the runner.</p>
   <p>It may also be a different directory when testing your project through the IDE, as then the game files and the runner are in different locations as well.</p>
   <p>When using this directory to write out a file, <span data-keyref="GameMaker Name">GameMaker</span> will redirect it to the <span class="inline2"><a data-xref="{title}" href="../../General_Game_Control/game_save_id.htm">game_save_id</a></span> location if the <a href="../../../../Additional_Information/The_File_System.htm">file system sandbox</a> does not allow writing to the working directory (this is the default behaviour, which can be disabled in the <a data-xref="{title}" href="../../../../Settings/Game_Options.htm">Game Options</a> for Desktop targets only).</p>

--- a/Manual/contents/IDE_Tools/The_Debugger/Watches.htm
+++ b/Manual/contents/IDE_Tools/The_Debugger/Watches.htm
@@ -75,8 +75,8 @@
   <div class="droptext" data-targetname="drop-down11">
     <p class="dropspot">If you have initialised any buffers in your game, then this window will show you the <strong>buffer data</strong>. You can select any buffer created by setting the <strong>Buffer ID</strong> value, which will start at 0 for the first buffer created in your game, and increment by 1 for each consecutive buffer: </p>
     <p class="dropspot"><img alt="Debug Buffer Window" class="center" src="../../assets/Images/IDE Tools/Debug_Buffer.png" />If you right-click <img alt="RMB Icon" class="icon" height="24" src="../../assets/Images/Icons/Icon_RMB.png" width="21" /> on the data window or click the <strong>Data Display</strong> button, you can select how the data is displayed, setting the <em>alignment </em>and <em>type</em>, and you can also set how the data is laid out from the <strong>Column Select</strong> box. There is a drop-down window here where you can select from a default list of layouts.</p>
+    <p class="note"><span data-conref="../../assets/snippets/Tag_note.hts"> </span> You can set the alignment to 1-byte Integer to get an exact view on the order of individual bytes in the buffer.</p>
   </div>
-  <p> </p>
   <p> </p>
   <p> </p>
   <div class="footer">
@@ -86,7 +86,7 @@
         <div style="float:right">Next: <a data-xref="{title}" href="The_Profiler.htm">The Profiler</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 Variable Watches

--- a/Manual/contents/The_Asset_Editors/Object_Properties/Async_Events/Audio_Playback_Ended.htm
+++ b/Manual/contents/The_Asset_Editors/Object_Properties/Async_Events/Audio_Playback_Ended.htm
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <title>Audio Playback Ended</title>
   <meta name="topic-status" content="Draft" />
   <link rel="stylesheet" type="text/css" href="../../../assets/css/default.css" />
@@ -16,18 +16,18 @@
 </head>
 <body>
   <h1><span data-field="title" data-format="default">Audio Playback Ended</span></h1>
-  <p><img class="center" src="../../../assets/Images/Asset_Editors/Async_AudioPlaybackEnded.png" style="cursor: nesw-resize;" />This event is triggered whenever playback ends for a sound instance played using the <span class="inline2">audio_play_sound_</span> functions.</p>
+  <p><img alt="Audio Playback Ended Event" class="center" src="../../../assets/Images/Asset_Editors/Async_AudioPlaybackEnded.png" />This event is triggered whenever playback ends for a sound instance played using the <span class="inline2">audio_play_sound_</span> functions.</p>
   <p>Playback of a sound ends in the following situations: </p>
   <ul class="colour">
     <li>The sound <strong>reaches its end position</strong>. Pausing a sound using <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asset_Management/Audio/audio_pause_sound.htm">audio_pause_sound</a></span>, changing its track position using <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asset_Management/Audio/audio_sound_set_track_position.htm">audio_sound_set_track_position</a></span> or looping a section of it by changing the <a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Loop_Points/Audio_Loop_Points.htm">Audio Loop Points</a> postpones the end of playback as the sound doesn&#39;t reach the end position this way.</li>
     <li>The sound is <strong>stopped</strong>, through a call to <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asset_Management/Audio/audio_stop_sound.htm">audio_stop_sound</a></span> or <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asset_Management/Audio/audio_stop_all.htm">audio_stop_all</a></span>. I.e. stopping a sound also <em>always</em> means it ends playback.</li>
-    <li>The sound is <strong>forced to stop</strong> due to <em>voice stealing</em>: when another sound is played using any of the <span class="inline2">audio_play_sound_</span> functions and all channels are used (see <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asset_Management/Audio/audio_channel_num.htm">audio_channel_num</a></span>), a channel playing a sound with a lower priority than the new one will be used to play the new sound, i.e. the channel is <em>stolen</em> by the new sound. An <span data-field="title" data-format="default">Audio Playback Ended</span> event is triggered for the sound that was forced to stop playing.</li>
+    <li>The sound can be <strong>forced to stop</strong> due to <em>voice stealing</em>: when another sound is played using any of the <span class="inline2">audio_play_sound_</span> functions and all channels are used (see <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asset_Management/Audio/audio_channel_num.htm">audio_channel_num</a></span>), a channel playing a sound with a lower priority than the new one will be used to play the new sound, i.e. the channel is <em>stolen</em> by the new sound. A sound can also be force-stopped when the emitter it is playing on is freed using <span class="inline3_func"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Emitters/audio_emitter_free.htm">audio_emitter_free</a></span>. An <span data-field="title" data-format="default">Audio Playback Ended</span> event is triggered for the sound that was forced to stop playing.</li>
   </ul>
   <p>The event will trigger in all objects that have it, for any sound played in the game (even when it&#39;s not played by the same object).</p>
   <p>The event returns information in the <span class="inline2"><a data-xref="{title}" href="../../../GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span> ds_map. The map contains the following keys in case of an <span data-field="title" data-format="default">Audio Playback Ended</span> event: </p>
   <ul class="colour">
-    <li><strong>&quot;sound_id&quot;</strong> - the <span data-keyref="Type_ID_Sound_Instance"><a href="../../../../GameMaker_Language/GML_Reference/Asset_Management/Audio/audio_play_sound.htm" target="_blank">Sound Instance ID</a></span> that ended playback.</li>
-    <li><strong>&quot;asset_id&quot;</strong> - the index of the <span data-keyref="Type_Asset_Sound"><a href="../../../../The_Asset_Editors/Sounds.htm" target="_blank">Sound Asset</a></span>.</li>
+    <li><strong>&quot;sound_id&quot;</strong> - the <span data-keyref="Type_ID_Sound_Instance"><a href="../../../GameMaker_Language/GML_Reference/Asset_Management/Audio/audio_play_sound.htm" target="_blank">Sound Instance ID</a></span> that ended playback.</li>
+    <li><strong>&quot;asset_id&quot;</strong> - the index of the <span data-keyref="Type_Asset_Sound"><a href="../../Sounds.htm" target="_blank">Sound Asset</a></span>.</li>
     <li><strong>&quot;was_stopped&quot;</strong> - this is set to <span class="inline2">false</span>, unless the sound was stopped manually using the <span class="inline2">audio_stop_</span> functions or when it was forced to stop playing.</li>
   </ul>
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> <em>Pausing</em> a sound does <em>not</em> end playback, as playback can still be <em>resumed</em> afterwards.</p>
@@ -61,7 +61,7 @@
         <div>Next: <a data-xref="{title}" href="Audio_Recording.htm">Audio Recording</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
 </body>
 </html>

--- a/Manual/contents/assets/css/default.css
+++ b/Manual/contents/assets/css/default.css
@@ -1046,7 +1046,7 @@ p {
   font-family: 'open_sansregular';
   line-height: 1.5;
 }
-/* hightlight.js (GML)*/
+/* highlight.js (GML and GLSL)*/
 pre code.hljs {
   display: block;
   overflow-x: auto;
@@ -1091,7 +1091,7 @@ code.hljs {
   color: #FFF899;
 }
 .hljs-function {
-  color: #ffb871;
+  color: #FFB871;
 }
 .hljs-addition,
 .hljs-attribute,
@@ -1119,11 +1119,23 @@ code.hljs {
 .hljs-variable {
   color: silver;
 }
+.hljs-type {
+  color: #FFB871;
+}
 .hljs-emphasis {
   font-style: italic;
 }
 .hljs-strong {
   font-weight: 700;
+}
+.hljs-title.function_ {
+  color: #FFB871;
+}
+.hljs-built_in {
+  color: #58E55A;
+}
+.hljs-property {
+  color: #FF8080;
 }
 :root {
   --hdrevenrows-theme-color: #ed7d31;

--- a/Manual/contents/assets/scripts/glsl.js
+++ b/Manual/contents/assets/scripts/glsl.js
@@ -1,0 +1,173 @@
+/*
+Language: GLSL
+Description: OpenGL Shading Language
+Author: Sergey Tikhomirov <sergey@tikhomirov.io>
+Website: https://en.wikipedia.org/wiki/OpenGL_Shading_Language
+Category: graphics
+*/
+
+/**
+ * Changes and additions for the GameMaker manual:
+ * 
+ * * Single-line comment regex replaced with a custom one (copied over from gml.js)
+ * * Vector component swizzle highlighting
+ * * Functions moved from built_in (Functions) -> 'title.function'
+ * * GM-specific additions:
+ *     * Built-in shader constants starting with "gm_" added to built_in
+ *     * Built-in matrix constants and MAX_VS_LIGHTS added to literal
+ * 
+ */
+
+export default function(hljs) {
+  /** Regex for a valid swizzle combination. */
+  const VALID_SWIZZLE_REG = /([xyzw]{1,4}|[rgba]{1,4}|[stpq]{1,4})\b/;
+  
+  /**
+   * A single-line comment.
+   */
+  const COMMENT_LINE = hljs.COMMENT('//', /\$|\n/);
+  /**
+   * Modes for the types of comments supported in GLSL.
+   */
+  const COMMENT = {
+    variants: [
+      COMMENT_LINE,
+      hljs.C_BLOCK_COMMENT_MODE,
+    ]
+  };
+  
+  const SWIZZLE = {
+    match: [
+      '[.]',
+      VALID_SWIZZLE_REG,
+    ],
+    className: {
+      2: "property"
+    },
+  };
+  
+  return {
+    name: 'GLSL',
+    keywords: {
+      keyword:
+        // Statements
+        'break continue discard do else for if return while switch case default '
+        // Qualifiers
+        + 'attribute binding buffer ccw centroid centroid varying coherent column_major const cw '
+        + 'depth_any depth_greater depth_less depth_unchanged early_fragment_tests equal_spacing '
+        + 'flat fractional_even_spacing fractional_odd_spacing highp in index inout invariant '
+        + 'invocations isolines layout line_strip lines lines_adjacency local_size_x local_size_y '
+        + 'local_size_z location lowp max_vertices mediump noperspective offset origin_upper_left '
+        + 'out packed patch pixel_center_integer point_mode points precise precision quads r11f_g11f_b10f '
+        + 'r16 r16_snorm r16f r16i r16ui r32f r32i r32ui r8 r8_snorm r8i r8ui readonly restrict '
+        + 'rg16 rg16_snorm rg16f rg16i rg16ui rg32f rg32i rg32ui rg8 rg8_snorm rg8i rg8ui rgb10_a2 '
+        + 'rgb10_a2ui rgba16 rgba16_snorm rgba16f rgba16i rgba16ui rgba32f rgba32i rgba32ui rgba8 '
+        + 'rgba8_snorm rgba8i rgba8ui row_major sample shared smooth std140 std430 stream triangle_strip '
+        + 'triangles triangles_adjacency uniform varying vertices volatile writeonly',
+      type:
+        'atomic_uint bool bvec2 bvec3 bvec4 dmat2 dmat2x2 dmat2x3 dmat2x4 dmat3 dmat3x2 dmat3x3 '
+        + 'dmat3x4 dmat4 dmat4x2 dmat4x3 dmat4x4 double dvec2 dvec3 dvec4 float iimage1D iimage1DArray '
+        + 'iimage2D iimage2DArray iimage2DMS iimage2DMSArray iimage2DRect iimage3D iimageBuffer '
+        + 'iimageCube iimageCubeArray image1D image1DArray image2D image2DArray image2DMS image2DMSArray '
+        + 'image2DRect image3D imageBuffer imageCube imageCubeArray int isampler1D isampler1DArray '
+        + 'isampler2D isampler2DArray isampler2DMS isampler2DMSArray isampler2DRect isampler3D '
+        + 'isamplerBuffer isamplerCube isamplerCubeArray ivec2 ivec3 ivec4 mat2 mat2x2 mat2x3 '
+        + 'mat2x4 mat3 mat3x2 mat3x3 mat3x4 mat4 mat4x2 mat4x3 mat4x4 sampler1D sampler1DArray '
+        + 'sampler1DArrayShadow sampler1DShadow sampler2D sampler2DArray sampler2DArrayShadow '
+        + 'sampler2DMS sampler2DMSArray sampler2DRect sampler2DRectShadow sampler2DShadow sampler3D '
+        + 'samplerBuffer samplerCube samplerCubeArray samplerCubeArrayShadow samplerCubeShadow '
+        + 'image1D uimage1DArray uimage2D uimage2DArray uimage2DMS uimage2DMSArray uimage2DRect '
+        + 'uimage3D uimageBuffer uimageCube uimageCubeArray uint usampler1D usampler1DArray '
+        + 'usampler2D usampler2DArray usampler2DMS usampler2DMSArray usampler2DRect usampler3D '
+        + 'samplerBuffer usamplerCube usamplerCubeArray uvec2 uvec3 uvec4 vec2 vec3 vec4 void',
+      built_in:
+        // Constants
+        'gl_MaxAtomicCounterBindings gl_MaxAtomicCounterBufferSize gl_MaxClipDistances gl_MaxClipPlanes '
+        + 'gl_MaxCombinedAtomicCounterBuffers gl_MaxCombinedAtomicCounters gl_MaxCombinedImageUniforms '
+        + 'gl_MaxCombinedImageUnitsAndFragmentOutputs gl_MaxCombinedTextureImageUnits gl_MaxComputeAtomicCounterBuffers '
+        + 'gl_MaxComputeAtomicCounters gl_MaxComputeImageUniforms gl_MaxComputeTextureImageUnits '
+        + 'gl_MaxComputeUniformComponents gl_MaxComputeWorkGroupCount gl_MaxComputeWorkGroupSize '
+        + 'gl_MaxDrawBuffers gl_MaxFragmentAtomicCounterBuffers gl_MaxFragmentAtomicCounters '
+        + 'gl_MaxFragmentImageUniforms gl_MaxFragmentInputComponents gl_MaxFragmentInputVectors '
+        + 'gl_MaxFragmentUniformComponents gl_MaxFragmentUniformVectors gl_MaxGeometryAtomicCounterBuffers '
+        + 'gl_MaxGeometryAtomicCounters gl_MaxGeometryImageUniforms gl_MaxGeometryInputComponents '
+        + 'gl_MaxGeometryOutputComponents gl_MaxGeometryOutputVertices gl_MaxGeometryTextureImageUnits '
+        + 'gl_MaxGeometryTotalOutputComponents gl_MaxGeometryUniformComponents gl_MaxGeometryVaryingComponents '
+        + 'gl_MaxImageSamples gl_MaxImageUnits gl_MaxLights gl_MaxPatchVertices gl_MaxProgramTexelOffset '
+        + 'gl_MaxTessControlAtomicCounterBuffers gl_MaxTessControlAtomicCounters gl_MaxTessControlImageUniforms '
+        + 'gl_MaxTessControlInputComponents gl_MaxTessControlOutputComponents gl_MaxTessControlTextureImageUnits '
+        + 'gl_MaxTessControlTotalOutputComponents gl_MaxTessControlUniformComponents '
+        + 'gl_MaxTessEvaluationAtomicCounterBuffers gl_MaxTessEvaluationAtomicCounters '
+        + 'gl_MaxTessEvaluationImageUniforms gl_MaxTessEvaluationInputComponents gl_MaxTessEvaluationOutputComponents '
+        + 'gl_MaxTessEvaluationTextureImageUnits gl_MaxTessEvaluationUniformComponents '
+        + 'gl_MaxTessGenLevel gl_MaxTessPatchComponents gl_MaxTextureCoords gl_MaxTextureImageUnits '
+        + 'gl_MaxTextureUnits gl_MaxVaryingComponents gl_MaxVaryingFloats gl_MaxVaryingVectors '
+        + 'gl_MaxVertexAtomicCounterBuffers gl_MaxVertexAtomicCounters gl_MaxVertexAttribs gl_MaxVertexImageUniforms '
+        + 'gl_MaxVertexOutputComponents gl_MaxVertexOutputVectors gl_MaxVertexTextureImageUnits '
+        + 'gl_MaxVertexUniformComponents gl_MaxVertexUniformVectors gl_MaxViewports gl_MinProgramTexelOffset '
+        // Variables
+        + 'gl_BackColor gl_BackLightModelProduct gl_BackLightProduct gl_BackMaterial '
+        + 'gl_BackSecondaryColor gl_ClipDistance gl_ClipPlane gl_ClipVertex gl_Color '
+        + 'gl_DepthRange gl_EyePlaneQ gl_EyePlaneR gl_EyePlaneS gl_EyePlaneT gl_Fog gl_FogCoord '
+        + 'gl_FogFragCoord gl_FragColor gl_FragCoord gl_FragData gl_FragDepth gl_FrontColor '
+        + 'gl_FrontFacing gl_FrontLightModelProduct gl_FrontLightProduct gl_FrontMaterial '
+        + 'gl_FrontSecondaryColor gl_GlobalInvocationID gl_InstanceID gl_InvocationID gl_Layer gl_LightModel '
+        + 'gl_LightSource gl_LocalInvocationID gl_LocalInvocationIndex gl_ModelViewMatrix '
+        + 'gl_ModelViewMatrixInverse gl_ModelViewMatrixInverseTranspose gl_ModelViewMatrixTranspose '
+        + 'gl_ModelViewProjectionMatrix gl_ModelViewProjectionMatrixInverse gl_ModelViewProjectionMatrixInverseTranspose '
+        + 'gl_ModelViewProjectionMatrixTranspose gl_MultiTexCoord0 gl_MultiTexCoord1 gl_MultiTexCoord2 '
+        + 'gl_MultiTexCoord3 gl_MultiTexCoord4 gl_MultiTexCoord5 gl_MultiTexCoord6 gl_MultiTexCoord7 '
+        + 'gl_Normal gl_NormalMatrix gl_NormalScale gl_NumSamples gl_NumWorkGroups gl_ObjectPlaneQ '
+        + 'gl_ObjectPlaneR gl_ObjectPlaneS gl_ObjectPlaneT gl_PatchVerticesIn gl_Point gl_PointCoord '
+        + 'gl_PointSize gl_Position gl_PrimitiveID gl_PrimitiveIDIn gl_ProjectionMatrix gl_ProjectionMatrixInverse '
+        + 'gl_ProjectionMatrixInverseTranspose gl_ProjectionMatrixTranspose gl_SampleID gl_SampleMask '
+        + 'gl_SampleMaskIn gl_SamplePosition gl_SecondaryColor gl_TessCoord gl_TessLevelInner gl_TessLevelOuter '
+        + 'gl_TexCoord gl_TextureEnvColor gl_TextureMatrix gl_TextureMatrixInverse gl_TextureMatrixInverseTranspose '
+        + 'gl_TextureMatrixTranspose gl_Vertex gl_VertexID gl_ViewportIndex gl_WorkGroupID gl_WorkGroupSize gl_in gl_out '
+        // GM-Specific
+        + 'gm_Matrices gm_BaseTexture gm_LightingEnabled gm_Lights_Direction gm_Lights_PosRange gm_Lights_Colour gm_AmbientColour gm_FogStart gm_RcpFogRange gm_PS_FogEnabled gm_FogColour gm_VS_FogEnabled gm_AlphaTestEnabled gm_AlphaRefValue',
+      literal:
+        'true false '
+        // Constants ("defines")
+        + 'MATRIX_VIEW MATRIX_PROJECTION MATRIX_WORLD MATRIX_WORLD_VIEW MATRIX_WORLD_VIEW_PROJECTION '
+        + 'MATRICES_MAX MAX_VS_LIGHTS ',
+      'title.function':
+        // Functions (moved from built_in)
+        'EmitStreamVertex EmitVertex EndPrimitive EndStreamPrimitive abs acos acosh all any asin '
+        + 'asinh atan atanh atomicAdd atomicAnd atomicCompSwap atomicCounter atomicCounterDecrement '
+        + 'atomicCounterIncrement atomicExchange atomicMax atomicMin atomicOr atomicXor barrier '
+        + 'bitCount bitfieldExtract bitfieldInsert bitfieldReverse ceil clamp cos cosh cross '
+        + 'dFdx dFdy degrees determinant distance dot equal exp exp2 faceforward findLSB findMSB '
+        + 'floatBitsToInt floatBitsToUint floor fma fract frexp ftransform fwidth greaterThan '
+        + 'greaterThanEqual groupMemoryBarrier imageAtomicAdd imageAtomicAnd imageAtomicCompSwap '
+        + 'imageAtomicExchange imageAtomicMax imageAtomicMin imageAtomicOr imageAtomicXor imageLoad '
+        + 'imageSize imageStore imulExtended intBitsToFloat interpolateAtCentroid interpolateAtOffset '
+        + 'interpolateAtSample inverse inversesqrt isinf isnan ldexp length lessThan lessThanEqual log '
+        + 'log2 matrixCompMult max memoryBarrier memoryBarrierAtomicCounter memoryBarrierBuffer '
+        + 'memoryBarrierImage memoryBarrierShared min mix mod modf noise1 noise2 noise3 noise4 '
+        + 'normalize not notEqual outerProduct packDouble2x32 packHalf2x16 packSnorm2x16 packSnorm4x8 '
+        + 'packUnorm2x16 packUnorm4x8 pow radians reflect refract round roundEven shadow1D shadow1DLod '
+        + 'shadow1DProj shadow1DProjLod shadow2D shadow2DLod shadow2DProj shadow2DProjLod sign sin sinh '
+        + 'smoothstep sqrt step tan tanh texelFetch texelFetchOffset texture texture1D texture1DLod '
+        + 'texture1DProj texture1DProjLod texture2D texture2DLod texture2DProj texture2DProjLod '
+        + 'texture3D texture3DLod texture3DProj texture3DProjLod textureCube textureCubeLod '
+        + 'textureGather textureGatherOffset textureGatherOffsets textureGrad textureGradOffset '
+        + 'textureLod textureLodOffset textureOffset textureProj textureProjGrad textureProjGradOffset '
+        + 'textureProjLod textureProjLodOffset textureProjOffset textureQueryLevels textureQueryLod '
+        + 'textureSize transpose trunc uaddCarry uintBitsToFloat umulExtended unpackDouble2x32 '
+        + 'unpackHalf2x16 unpackSnorm2x16 unpackSnorm4x8 unpackUnorm2x16 unpackUnorm4x8 usubBorrow ',
+    },
+    illegal: '"',
+    contains: [
+      //hljs.C_LINE_COMMENT_MODE,
+      COMMENT,
+      hljs.C_NUMBER_MODE,
+      {
+        className: 'meta',
+        begin: '#',
+        end: '$'
+      },
+      SWIZZLE,
+    ]
+  };
+}

--- a/Manual/contents/assets/scripts/main_script.js
+++ b/Manual/contents/assets/scripts/main_script.js
@@ -1,3 +1,7 @@
+// ----------------------------------------------------------------------------------------------
+// Code highlighter
+// ----------------------------------------------------------------------------------------------
+
 /*!
   Highlight.js v11.0.1 (git: 1cf31f015d)
   (c) 2006-2021 Ivan Sagalaev and other contributors
@@ -9,7 +13,6 @@
 	It also uses a new function escapeHTMLCustom()
 	C_LINE_COMMENT_MODE got another regex added for detecting <br>s
  */
-import gmljs from "./gml.js";
 
 var hljs = (function () {
     'use strict';
@@ -2554,10 +2557,14 @@ var hljs = (function () {
 }());
 if (typeof exports === 'object' && typeof module !== 'undefined') { module.exports = hljs; }
 
-
+// Load and register language definitions used for code highlighting
+import gmljs from "./gml.js";
+import glsljs from "./glsl.js";
 
 hljs.registerLanguage("gml", gmljs);
+hljs.registerLanguage("glsl", glsljs);
 
+// Trigger code highlighting on page load
 document.addEventListener('DOMContentLoaded', (event) => {
   // Turn return code blocks into plain blocks
    var h4s = document.getElementsByTagName("h4");

--- a/Manual/contents/assets/snippets/Code_Snippet_Shader_Linearize_Depth.hts
+++ b/Manual/contents/assets/snippets/Code_Snippet_Shader_Linearize_Depth.hts
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="../css/default.css" />
 </head>
 <body>
-  <p class="code"><span>/// @param depth Non-linear depth.<br />
+  <p class="code language-glsl"><span>/// @param depth Non-linear depth.<br />
       /// @param zparam Equals (zfar / znear).<br />
       /// @return Linearized depth, in range 0..1.<br />
       float LinearizeDepth(float depth, float zparam)<br />

--- a/Manual/contents/assets/snippets/buffer_data_type_constants.hts
+++ b/Manual/contents/assets/snippets/buffer_data_type_constants.hts
@@ -20,7 +20,7 @@
       <tr>
         <th>Constant</th>
         <th>Description</th>
-        <th>Datatype Returned</th>
+        <th>Datatype</th>
       </tr>
       <tr>
         <td><span class="inline">buffer_u8</span></td>
@@ -74,7 +74,7 @@
       </tr>
       <tr>
         <td><span class="inline">buffer_bool</span></td>
-        <td>A boolean value, can only be either 1 or 0 (<span class="inline">true</span> or <span class="inline">false</span>). It is stored in a single byte (8bit)</td>
+        <td>A boolean value, can only be either 1 or 0 (<span class="inline2">true</span> or <span class="inline2">false</span>). It is stored in a single byte (8bit).</td>
         <td>int32</td>
       </tr>
       <tr>
@@ -89,5 +89,6 @@
       </tr>
     </tbody>
   </table>
+  <p class="note"><span data-conref="Tag_note.hts"> </span> Number types that take up multiple bytes in the buffer are read/written using the <a href="http://en.wikipedia.org/wiki/Endianness">endianness</a> of the target platform. This endianness is <strong>little endian</strong> for all platforms supported by <span data-keyref="GameMaker Name">GameMaker</span>.</p>
 </body>
 </html>


### PR DESCRIPTION
This PR has changes to the manual for the following:

* `audio_emitter_free()` force-stops playing sounds (https://github.com/YoYoGames/GameMaker-Bugs/issues/13759)
* Built-in directory variables don't "return" a value (https://github.com/YoYoGames/GameMaker-Bugs/issues/13888)
* Support for highlighting of GLSL code blocks, using a modified version of [this GLSL language definition](https://github.com/highlightjs/highlight.js/blob/main/src/languages/glsl.js) - licensing to be checked (https://github.com/YoYoGames/GameMaker-Bugs/issues/13862)
* Endianness of buffer numbers reading/writing (https://github.com/YoYoGames/GameMaker-Bugs/issues/13872)