### PR TITLE
Description for GM2018, weld joint angle in degrees and various other physics docs fixes, other small changes and fixes

### DIFF
--- a/Manual/contents/Additional_Information/Guide_To_Using_Shaders.htm
+++ b/Manual/contents/Additional_Information/Guide_To_Using_Shaders.htm
@@ -305,7 +305,7 @@
       vec3 hsv2rgb(vec3 c) <br />
       {<br />
           vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);<br />
-        vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);<br />
+          vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);<br />
           return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);<br />
       }<br />
       <br />
@@ -374,7 +374,7 @@
           vec4 texColor = texture2D(gm_BaseTexture, v_vTexcoord);<br />
           <br />
           vec3 col = vec3(u_section * ((u_time * u_speed) + pos), u_saturation, u_brightness);<br />
-        vec4 finalCol = mix(texColor, vec4(hsv2rgb(col), texColor.a), u_mix);<br />
+          vec4 finalCol = mix(texColor, vec4(hsv2rgb(col), texColor.a), u_mix);<br />
           <br />
           gl_FragColor = v_vColour * finalCol;<br />
       }

--- a/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/cache_directory.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/cache_directory.htm
@@ -26,8 +26,8 @@
   <p class="code"><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code">ini_open(<span data-field="title" data-format="default">cache_directory</span> + &quot;\cache_ini.ini&quot;);</p>
-  <p>This will open an INI file in the cache directory of the game (creating it if it does not already exist).</p>
+  <p class="code">ini_open(<span data-field="title" data-format="default">cache_directory</span> + &quot;cache_ini.ini&quot;);</p>
+  <p>This will open an INI file in the cache directory of the game (creating it if it doesn&#39;t already exist).</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/temp_directory.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/temp_directory.htm
@@ -26,8 +26,8 @@
   <p class="code"><span data-keyref="Type_String"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">String</a></span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code">ini_open(<span data-field="title" data-format="default">temp_directory</span> + &quot;\temp_ini.ini&quot;);</p>
-  <p>This will open an INI file in the temporary directory of the game (creating it if it does not already exist).</p>
+  <p class="code">ini_open(<span data-field="title" data-format="default">temp_directory</span> + &quot;temp_ini.ini&quot;);</p>
+  <p>This will open an INI file in the temporary directory of the game (creating it if it doesn&#39;t already exist).</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/working_directory.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/File_Handling/File_Directories/working_directory.htm
@@ -31,7 +31,7 @@
   <p> </p>
   <h4>Example:</h4>
   <p class="code">ini_open(working_directory + &quot;temp_ini.ini&quot;);</p>
-  <p>This will open an INI file from the working directory of the game (creating it if it does not already exist). This could be the save area or the program directory depending on the sandbox level.</p>
+  <p>This will open an INI file from the working directory of the game (creating it if it doesn&#39;t already exist). This could be the save area or the program directory depending on the sandbox level.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/Fixtures.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/Fixtures.htm
@@ -33,7 +33,7 @@
     physics_fixture_set_collision_group(fix, 1);<br />
     physics_fixture_set_density(fix, 1);<br />
     <br />
-    physics_fixture_bind(fix, id);
+    fix_bound = physics_fixture_bind(fix, id);
   </p>
   <p>The code above sets the collision group to 1 so the fixture collides with other fixtures (as this is the default collision group for fixtures created via the IDE) and sets a density so it is affected by gravity. It then binds the fixture to the current instance. You can test this by calling <span class="inline3_func"><a data-xref="{title}" href="../The_Physics_World/physics_draw_debug.htm">physics_draw_debug</a></span> in a Draw event to draw the fixtures associated with the instance to the screen for debugging purposes.</p>
   <div data-conref="../../../../assets/snippets/Note_physics_fixture_define.hts"> </div>
@@ -52,7 +52,7 @@
   <p>Two physics instances are &quot;in contact&quot; when their bounding boxes overlap (i.e. the rectangular regions surrounding their actual shapes). In this case, calling one of the <span class="inline3_func">physics_set_*</span> functions on a bound fixture <em>will change</em> the value of the property, but in order to force the physics engine to also <em>take this new value into account</em>, you&#39;ll need to deactivate and reactivate the physics instance using <span class="inline2"><a data-xref="{title}" href="../Physics_Variables/phy_active.htm">phy_active</a></span>: </p>
   <p class="code">var _new_friction = 100;<br />
     phy_active = false;<br />
-    physics_set_friction(fixture_id, _new_friction);<br />
+    physics_set_friction(bound_fixture_id, _new_friction);<br />
     phy_active = true;</p>
   <h2 id="func_ref">Function Reference</h2>
   <h3 id="func_ref_general">General</h3>
@@ -87,7 +87,7 @@
     <li><a data-xref="{title}" href="physics_fixture_set_collision_group.htm">physics_fixture_set_collision_group</a></li>
   </ul>
   <h3 id="func_ref_modify">Modifying Bound Fixtures</h3>
-  <p>You can also set certain properties of the fixture <i>after</i> it has been bound to an instance. When binding the &quot;base&quot; fixture, you can choose to store the unique index for the bound physical properties in a variable. This can then be used in the following functions to change certain properties, or to get the current values for them: </p>
+  <p>You can also set certain properties of the fixture <i>after</i> it has been <a href="physics_fixture_bind.htm">bound</a> to an instance. When binding the &quot;base&quot; fixture, you can choose to store the unique index for the bound physical properties in a variable. This can then be used in the following functions to change certain properties, or to get the current values for them: </p>
   <ul class="colour">
     <li><a href="physics_get_friction.htm">physics_get_friction</a></li>
     <li><a href="physics_get_density.htm">physics_get_density</a></li>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/Fixtures.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/Fixtures.htm
@@ -56,36 +56,35 @@
     phy_active = true;</p>
   <h2 id="func_ref">Function Reference</h2>
   <h3 id="func_ref_general">General</h3>
-  <p>The following functions are for creating, binding, setting collisions and then deleting fixtures:</p>
+  <p>The following functions are used to create, bind and delete fixtures:</p>
   <ul class="colour">
-    <li><a href="physics_fixture_create.htm">physics_fixture_create</a></li>
-    <li><a href="physics_fixture_bind.htm">physics_fixture_bind</a></li>
-    <li><a href="physics_fixture_bind_ext.htm">physics_fixture_bind_ext</a></li>
-    <li><a href="physics_fixture_set_collision_group.htm">physics_fixture_set_collision_group</a></li>
-    <li><a href="physics_fixture_delete.htm">physics_fixture_delete</a></li>
-    <li><a href="physics_remove_fixture.htm">physics_remove_fixture</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_create.htm">physics_fixture_create</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_bind.htm">physics_fixture_bind</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_bind_ext.htm">physics_fixture_bind_ext</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_delete.htm">physics_fixture_delete</a></li>
   </ul>
   <h3 id="func_ref_shapes">Shapes</h3>
   <p>A fixture must be given a shape or else it will not be detected by the physics world, and this shape can be defined by the following functions:</p>
   <ul class="colour">
-    <li><a href="physics_fixture_set_box_shape.htm">physics_fixture_set_box_shape</a></li>
-    <li><a href="physics_fixture_set_circle_shape.htm">physics_fixture_set_circle_shape</a></li>
-    <li><a href="physics_fixture_set_edge_shape.htm">physics_fixture_set_edge_shape</a></li>
-    <li><a href="physics_fixture_set_chain_shape.htm">physics_fixture_set_chain_shape</a></li>
-    <li><a href="physics_fixture_set_polygon_shape.htm">physics_fixture_set_polygon_shape</a></li>
-    <li><a href="physics_fixture_add_point.htm">physics_fixture_add_point</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_box_shape.htm">physics_fixture_set_box_shape</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_circle_shape.htm">physics_fixture_set_circle_shape</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_edge_shape.htm">physics_fixture_set_edge_shape</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_chain_shape.htm">physics_fixture_set_chain_shape</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_polygon_shape.htm">physics_fixture_set_polygon_shape</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_add_point.htm">physics_fixture_add_point</a></li>
   </ul>
   <h3 id="func_ref_setters">Setting Properties</h3>
   <p>In order for your physics enabled instance to react properly to the world around it, the fixtures you use must have specific properties defined that will give the fixture bounce, friction, mass, etc. The following functions are used to set these properties of the fixture:</p>
   <ul class="colour">
-    <li><a href="physics_fixture_set_density.htm">physics_fixture_set_density</a></li>
-    <li><a href="physics_fixture_set_friction.htm">physics_fixture_set_friction</a></li>
-    <li><a href="physics_fixture_set_linear_damping.htm">physics_fixture_set_linear_damping</a></li>
-    <li><a href="physics_fixture_set_angular_damping.htm">physics_fixture_set_angular_damping</a></li>
-    <li><a href="physics_fixture_set_restitution.htm">physics_fixture_set_restitution</a></li>
-    <li><a href="physics_fixture_set_sensor.htm">physics_fixture_set_sensor</a></li>
-    <li><a href="physics_fixture_set_kinematic.htm">physics_fixture_set_kinematic</a></li>
-    <li><a href="physics_fixture_set_awake.htm">physics_fixture_set_awake</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_density.htm">physics_fixture_set_density</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_friction.htm">physics_fixture_set_friction</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_linear_damping.htm">physics_fixture_set_linear_damping</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_angular_damping.htm">physics_fixture_set_angular_damping</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_restitution.htm">physics_fixture_set_restitution</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_sensor.htm">physics_fixture_set_sensor</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_kinematic.htm">physics_fixture_set_kinematic</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_awake.htm">physics_fixture_set_awake</a></li>
+    <li><a data-xref="{title}" href="physics_fixture_set_collision_group.htm">physics_fixture_set_collision_group</a></li>
   </ul>
   <h3 id="func_ref_modify">Modifying Bound Fixtures</h3>
   <p>You can also set certain properties of the fixture <i>after</i> it has been bound to an instance. When binding the &quot;base&quot; fixture, you can choose to store the unique index for the bound physical properties in a variable. This can then be used in the following functions to change certain properties, or to get the current values for them: </p>
@@ -96,18 +95,18 @@
     <li><a href="physics_set_friction.htm">physics_set_friction</a></li>
     <li><a href="physics_set_density.htm">physics_set_density</a></li>
     <li><a href="physics_set_restitution.htm">physics_set_restitution</a></li>
-    <li><a href="../physics_mass_properties.htm">physics_mass_properties</a></li>
+    <li><a data-xref="{title}" href="physics_remove_fixture.htm">physics_remove_fixture</a></li>
   </ul>
   <p> </p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="../Physics.htm">Physics</a></div>
-        <div style="float:right">Next: <a href="../Joints/Joints.htm">Joints</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="../Physics.htm">Physics</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="../Joints/Joints.htm">Joints</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 Fixtures

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind.htm
@@ -44,7 +44,7 @@
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></p>
+  <p class="code"><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">var _fix, _inst;<br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind.htm
@@ -16,9 +16,9 @@
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">physics_fixture_bind</span></h1>
   <p>This function binds the given fixture to the given target object or instance and returns the ID of the bound fixture.</p>
-  <p>Once we have defined our fixture it has to be bound to an instance. This means that its <i>properties</i> are transferred to the selected instance, <b>not the actual fixture itself</b>, so that one fixture can be bound to multiple instances if all are to have the same properties. You can specify an object index for the target and all instances of that object present in the room at the time will receive that fixture&#39;s properties (but not any new instances of the object created later), or you can use the special keywords <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Instance Keywords/other.htm">other</a></span> and <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Instance Keywords/all.htm">all</a></span>. You can even specify a parent object and all children instances with that parent will also receive the fixture. Once the fixture has been bound to all the instances that you need, it can be deleted if no longer necessary and the instances with that fixture&#39;s properties will not be affected and maintain those properties.</p>
+  <p>Once we have defined our fixture it has to be bound to an instance. This means that its <i>properties</i> are transferred to the selected instance, <b>not the actual fixture itself</b>, so that one fixture can be bound to multiple instances if all are to have the same properties. You can specify an object index for the target and all instances of that object present in the room at the time will receive that fixture&#39;s properties (but not any new instances of the object created later), or you can use the special keywords <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Instance Keywords/other.htm">other</a></span> and <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Instance Keywords/all.htm">all</a></span>. You can even specify a parent object and all instances that are instances of children of that parent object will also receive the fixture. Once the fixture has been bound to all the instances that you need, it can be deleted if no longer necessary and the instances with that fixture&#39;s properties will not be affected and maintain those properties.</p>
   <p>The fixture will be bound to the instance with the centre of mass being positioned at the origin of the instance, and polygon fixtures are bound based on the position of the points <i>relative</i> to the origin. If you require your fixture to be bound to a point other than the origin then you should be using <span class="inline3_func"><a data-xref="{title}" href="physics_fixture_bind_ext.htm">physics_fixture_bind_ext</a></span>.</p>
-  <p><img alt="Physics fixture binding example" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/physics_fixture_bind_image.png" />The function will also return a unique &quot;id&quot; value for the <i>bound</i> fixture (<b>not the fixture itself</b>) which can then be used to remove (&quot;un-bind&quot;) the physics properties from the instance using the function <span class="inline3_func"><a data-xref="{title}" href="physics_remove_fixture.htm">physics_remove_fixture</a></span>. This permits you to add and remove physical properties from an instance without destroying and re-creating objects.</p>
+  <p><img alt="Physics fixture binding example" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/physics_fixture_bind_image.png" />The function will also return a unique &quot;id&quot; value for the <i>bound</i> fixture (<b>not the fixture itself</b>) which can then be used to remove (&quot;un-bind&quot;) the physics properties from the instance using the function <span class="inline3_func"><a data-xref="{title}" href="physics_remove_fixture.htm">physics_remove_fixture</a></span>. This permits you to add and remove physical properties from an instance without destroying and re-creating instances.</p>
   <p class="note"><span data-conref="../../../../assets/snippets/Tag_note.hts"> </span> Fixtures should be deleted when no longer needed as failure to do so may cause a memory leak which will slow down and eventually crash your game.</p>
   <p> </p>
   <h4>Syntax:</h4>
@@ -47,14 +47,17 @@
   <p class="code"><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code">var _fix, _inst;<br />
-    _fix = physics_fixture_create();<br />
+  <p class="code_heading">Create Event</p>
+  <p class="code">var _fix = physics_fixture_create();<br />
     physics_fixture_set_circle_shape(_fix, 16);<br />
     physics_fixture_set_density(_fix, 1.0);<br />
-    inst = instance_create_layer(x, y, &quot;Instances&quot;, genericBodyObject);<br />
-    my_fix = physics_fixture_bind(_fix, inst);<br />
+    my_bound_fix = physics_fixture_bind(_fix, id);<br />
     physics_fixture_delete(_fix);</p>
-  <p>The code above will create a fixture and assign its index to the temporary variable <span class="inline2">_fix</span>. It then defines the shape and density of the fixture before binding it to the instance that was created with the index for the <b>bound</b> fixture stored in the variable <span class="inline2">my_fix</span>. Finally, the fixture is deleted to prevent memory leaks as it is no longer needed.</p>
+  <p class="code_heading">Clean Up Event</p>
+  <p class="code">physics_remove_fixture(id, my_bound_fix);</p>
+  <p>The code above shows how to bind a physics fixture to the instance executing the code and remove it afterwards.</p>
+  <p>In the Create event, a fixture is created and its index is assigned to a temporary variable <span class="inline2">_fix</span>. The shape and density of the fixture are then defined and the fixture is bound to the calling instance with the index for the <b>bound</b> fixture stored in the instance variable <span class="inline2">my_bound_fix</span>. Finally, the fixture is deleted to prevent memory leaks as it is no longer needed.</p>
+  <p>In the Clean Up event, the bound fixture is removed.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
@@ -64,7 +67,7 @@
         <div style="float:right">Next: <a data-xref="{title}" href="physics_fixture_bind_ext.htm">physics_fixture_bind_ext</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_fixture_bind

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind_ext.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind_ext.htm
@@ -19,7 +19,7 @@
   <p>Once we have defined our fixture it has to be bound to an instance. This means that its <i>properties</i> are transferred to the selected instance, <b>not the actual fixture itself</b>, so that one fixture can be bound to multiple instances if all are to have the same properties. You can specify an object index for the target and all instances present in the room at the time will receive that fixtures properties (but not any new instances of the object created later), or you can use the special keywords <i>other</i> and <i>all</i>. You can even specify a parent object and all children instances with that parent will also receive the fixture. Once the fixture has been bound to all the instances that you need, it can be deleted if no longer necessary and the instances with that fixtures properties will not be affected and maintain those properties.</p>
   <p>Normally, the fixture will be bound to the instance with the center of mass being positioned at the origin of the instance, however this is not always what you require and so this function also permits you to offset the x and y position where the fixture is bound by a given amount (if you do not require this then use <span class="inline3_func"><a data-xref="{title}" href="physics_fixture_bind.htm">physics_fixture_bind</a></span> instead).</p>
   <p class="note"><span data-conref="../../../../assets/snippets/Tag_important.hts"> </span> A fixture can only support a <i>single</i> offset, as adding multiple offsets to a single fixture is not supported by Box2D.</p>
-  <p><img alt="Extended physics fixture binding example" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/physics_fixture_bind_ext_image.png" />The function will also return a unique &quot;id&quot; value for the <i>bound</i> fixture (<b>not the fixture itself</b>) which can then be used to remove (&quot;un-bind&quot;) the physics properties from the instance using the function <span class="inline3_func"><a data-xref="{title}" href="physics_remove_fixture.htm">physics_remove_fixture</a></span>. This permits you to add and remove physical properties from an instance without destroying and re-creating objects.</p>
+  <p><img alt="Extended physics fixture binding example" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/physics_fixture_bind_ext_image.png" />The function will also return a unique &quot;ID&quot; value for the <i>bound</i> fixture (<b>not the fixture itself</b>) which can then be used to remove (&quot;un-bind&quot;) the physics properties from the instance using the function <span class="inline3_func"><a data-xref="{title}" href="physics_remove_fixture.htm">physics_remove_fixture</a></span>. This permits you to add and remove physical properties from an instance without destroying and re-creating instances.</p>
   <p class="note"><span data-conref="../../../../assets/snippets/Tag_note.hts"> </span> Fixtures should be deleted when no longer needed as failure to do so may cause a memory leak which will slow down and eventually crash your game.</p>
   <p> </p>
   <h4>Syntax:</h4>
@@ -39,7 +39,7 @@
       <tr>
         <td>target</td>
         <td><span data-keyref="Type_ID_Instance"><a href="../../Asset_Management/Instances/Instance_Variables/id.htm" target="_blank">Object Instance</a></span> or <span data-keyref="Type_Asset_Object"><a href="../../../../The_Asset_Editors/Objects.htm" target="_blank">Object Asset</a></span></td>
-        <td>The target instance that is to receive the fixture (can be an instance id, an object id, <i>other</i>, or <i>all</i>)</td>
+        <td>The target instance that is to receive the fixture (can be an instance, an object, <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Instance Keywords/other.htm">other</a></span> or <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Instance Keywords/all.htm">all</a></span>)</td>
       </tr>
       <tr>
         <td>xoffset</td>
@@ -58,24 +58,24 @@
   <p class="code"><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code">var fix, inst;<br />
-    fix = physics_fixture_create();<br />
-    physics_fixture_set_circle_shape(fix, 16);<br />
-    physics_fixture_set_density(fix, 1.0);<br />
-    inst = instance_create_layer(x, y, &quot;Instances&quot;, genericBodyObject);<br />
-    my_fix = physics_fixture_bind_ext(fix, inst, sprite_width / 2, -(sprite_height / 2));<br />
-    physics_fixture_delete(fix);</p>
-  <p>The code above will create a fixture and assign its index to the variable &quot;fix&quot;. It then defines the shape and density of the fixture before binding it to the instance at an offset based on the width and height of the sprite. The index for the <b>bound</b> fixture is stored in the variable &quot;my_fix&quot;. Finally, the fixture itself is deleted to prevent memory leaks as it is no longer needed.</p>
+  <p class="code">var _fix, inst;<br />
+    _fix = physics_fixture_create();<br />
+    physics_fixture_set_circle_shape(_fix, 16);<br />
+    physics_fixture_set_density(_fix, 1.0);<br />
+    inst = instance_create_layer(x, y, &quot;Instances&quot;, obj_body_generic);<br />
+    the_fix = physics_fixture_bind_ext(_fix, inst, sprite_width / 2, -(sprite_height / 2));<br />
+    physics_fixture_delete(_fix);</p>
+  <p>The code above will create a fixture and assign its index to the variable <span class="inline2">_fix</span>. It then defines the shape and density of the fixture before binding it to a newly created instance of an object <span class="inline2">obj_body_generic</span> at an offset based on the width and height of the sprite. The index for the <b>bound</b> fixture is stored in the variable <span class="inline2">the_fix</span>. Finally, the fixture itself is deleted to prevent memory leaks as it is no longer needed. Note that the bound fixture needs to be removed as well at some point with a call to <span class="inline3_func"><a data-xref="{title}" href="physics_remove_fixture.htm">physics_remove_fixture</a></span>.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Fixtures.htm">Fixtures</a></div>
-        <div style="float:right">Next: <a href="physics_fixture_set_collision_group.htm">physics_fixture_set_collision_group</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Fixtures.htm">Fixtures</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_fixture_set_collision_group.htm">physics_fixture_set_collision_group</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_fixture_bind_ext

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind_ext.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind_ext.htm
@@ -55,7 +55,7 @@
   </table>
   <p> </p>
   <h4>Returns:</h4>
-  <p class="code"><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></p>
+  <p class="code"><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></p>
   <p> </p>
   <h4>Example:</h4>
   <p class="code">var fix, inst;<br />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_get_density.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_get_density.htm
@@ -30,8 +30,8 @@
       </tr>
       <tr>
         <td>fixture</td>
-        <td><span data-keyref="Type_ID_PhyFixture"><a href="physics_fixture_create.htm" target="_blank">Physics Fixture ID</a></span></td>
-        <td>the ID of the bound fixture</td>
+        <td><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></td>
+        <td>The ID of the bound fixture</td>
       </tr>
     </tbody>
   </table>
@@ -42,7 +42,7 @@
   <h4>Example:</h4>
   <p class="code">var _density = physics_get_density(fix_id);<br />
     physics_set_density(fix_id, _density - 0.1);</p>
-  <p>The code above gets the current density value for the bound physics properties of the instance and then sets them to a different value.</p>
+  <p>The code above gets the current density value for the bound physics properties of the instance and then sets it to a different value.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
@@ -52,7 +52,7 @@
         <div style="float:right">Next: <a href="physics_get_restitution.htm">physics_get_restitution</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_get_density

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_get_friction.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_get_friction.htm
@@ -29,8 +29,8 @@
       </tr>
       <tr>
         <td>fixture</td>
-        <td><span data-keyref="Type_ID_PhyFixture"><a href="physics_fixture_create.htm" target="_blank">Physics Fixture ID</a></span></td>
-        <td>the ID of the bound fixture</td>
+        <td><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></td>
+        <td>The ID of the bound fixture</td>
       </tr>
     </tbody>
   </table>
@@ -41,7 +41,7 @@
   <h4>Example:</h4>
   <p class="code">var _fric = physics_get_friction(fix_id);<br />
     physics_set_friction(fix_id, _fric + 0.1);</p>
-  <p>The code above gets the current friction value for the bound physics properties of the instance and then sets them to a different value.</p>
+  <p>The code above gets the current friction value for the bound physics properties of the instance and then sets it to a different value.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
@@ -51,7 +51,7 @@
         <div style="float:right">Next: <a href="physics_get_density.htm">physics_get_density</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_fixture_set_awake

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_get_restitution.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_get_restitution.htm
@@ -30,8 +30,8 @@
       </tr>
       <tr>
         <td>fixture</td>
-        <td><span data-keyref="Type_ID_PhyFixture"><a href="physics_fixture_create.htm" target="_blank">Physics Fixture ID</a></span></td>
-        <td>the ID of the bound fixture</td>
+        <td><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></td>
+        <td>The ID of the bound fixture</td>
       </tr>
     </tbody>
   </table>
@@ -42,7 +42,7 @@
   <h4>Example:</h4>
   <p class="code">var _rest = physics_get_restitution(fix_id);<br />
     physics_set_restitution(fix_id, _rest * 2);</p>
-  <p>The code above gets the current restitution value for the bound physics properties of the instance and then sets them to a different value.</p>
+  <p>The code above gets the current restitution value for the bound physics properties of the instance and then sets it to a different value.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
@@ -52,7 +52,7 @@
         <div style="float:right">Next: <a href="physics_set_friction.htm">physics_set_friction</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_get_restitution

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_remove_fixture.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_remove_fixture.htm
@@ -35,7 +35,7 @@
       <tr>
         <td>fixture</td>
         <td><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></td>
-        <td>The ID of the bound fixture that is to be removed from the instance</td>
+        <td>The ID of the bound fixture that is to be removed</td>
       </tr>
     </tbody>
   </table>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_remove_fixture.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_remove_fixture.htm
@@ -34,7 +34,7 @@
       </tr>
       <tr>
         <td>fixture</td>
-        <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></td>
         <td>The ID of the bound fixture that is to be removed from the instance</td>
       </tr>
     </tbody>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_remove_fixture.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_remove_fixture.htm
@@ -29,8 +29,8 @@
       </tr>
       <tr>
         <td>id</td>
-        <td><span data-keyref="Type_ID_Instance"><a href="../../Asset_Management/Instances/Instance_Variables/id.htm" target="_blank">Object Instance</a></span></td>
-        <td>The ID of the instance to remove the fixture from</td>
+        <td><span data-keyref="Type_ID_Instance"><a href="../../Asset_Management/Instances/Instance_Variables/id.htm" target="_blank">Object Instance</a></span> or <span data-keyref="Type_Asset_Object"><a href="../../../../The_Asset_Editors/Objects.htm" target="_blank">Object Asset</a></span></td>
+        <td>The ID of the instance, or an object ID to remove the fixture from all instances of that object</td>
       </tr>
       <tr>
         <td>fixture</td>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_remove_fixture.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_remove_fixture.htm
@@ -15,7 +15,7 @@
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">physics_remove_fixture</span></h1>
-  <p>This function removes (or &quot;un-binds&quot;) a fixture from an instance or instances.</p>
+  <p>This function removes (or &quot;un-binds&quot;) a bound fixture from an instance or instances.</p>
   <p>It requires the unique &quot;ID&quot; of the bound fixture (as returned by the function <span class="inline3_func"><a data-xref="{title}" href="physics_fixture_bind.htm">physics_fixture_bind</a></span>) and it will remove all the currently defined physics properties for the instance, permitting you to redefine a new fixture and bind that to the instance. In this way you can change the instance&#39;s physical properties without having to destroy and re-create it.</p>
   <p> </p>
   <h4>Syntax:</h4>
@@ -34,8 +34,8 @@
       </tr>
       <tr>
         <td>fixture</td>
-        <td><span data-keyref="Type_ID_PhyFixture"><a href="physics_fixture_create.htm" target="_blank">Physics Fixture ID</a></span></td>
-        <td>The ID of the fixture that is to be removed from the instance</td>
+        <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td>The ID of the bound fixture that is to be removed from the instance</td>
       </tr>
     </tbody>
   </table>
@@ -44,18 +44,18 @@
   <p class="code"><span data-keyref="Type_Void">N/A</span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code">physics_remove_fixture(id, my_fix);</p>
-  <p>The code above will remove the fixture with the ID stored in the variable <span class="inline2">my_fix</span> from the instance.</p>
+  <p class="code"><span data-field="title" data-format="default">physics_remove_fixture</span>(id, my_bound_fix);</p>
+  <p>The code above will remove the fixture with the ID stored in the variable <span class="inline2">my_bound_fix</span> from the instance.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Fixtures.htm">Fixtures</a></div>
-        <div style="float:right">Next: <a href="physics_fixture_set_box_shape.htm">physics_fixture_set_box_shape</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Fixtures.htm">Fixtures</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_fixture_set_box_shape.htm">physics_fixture_set_box_shape</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_remove_fixture

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_set_density.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_set_density.htm
@@ -30,13 +30,13 @@
       </tr>
       <tr>
         <td>fixture</td>
-        <td><span data-keyref="Type_ID_PhyFixture"><a href="physics_fixture_create.htm" target="_blank">Physics Fixture ID</a></span></td>
-        <td>the ID of the bound fixture</td>
+        <td><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></td>
+        <td>The ID of the bound fixture</td>
       </tr>
       <tr>
         <td>density</td>
         <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
-        <td>the new density value to apply</td>
+        <td>The new density value to apply</td>
       </tr>
     </tbody>
   </table>
@@ -47,7 +47,7 @@
   <h4>Example:</h4>
   <p class="code">var _density = physics_get_density(fix_id);<br />
     physics_set_density(fix_id, _density - 0.1);</p>
-  <p>The code above gets the current density value for the bound physics properties of the instance and then sets them to a different value.</p>
+  <p>The code above gets the current density value for the bound physics properties of the instance and then sets it to a different value.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
@@ -57,7 +57,7 @@
         <div style="float:right">Next: <a href="physics_set_restitution.htm">physics_set_restitution</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_set_density

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_set_friction.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_set_friction.htm
@@ -30,13 +30,13 @@
       </tr>
       <tr>
         <td>fixture</td>
-        <td><span data-keyref="Type_ID_PhyFixture"><a href="physics_fixture_create.htm" target="_blank">Physics Fixture ID</a></span></td>
-        <td>the ID of the bound fixture</td>
+        <td><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></td>
+        <td>The ID of the bound fixture</td>
       </tr>
       <tr>
         <td>friction</td>
         <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
-        <td>the new friction value to apply</td>
+        <td>The new friction value to apply</td>
       </tr>
     </tbody>
   </table>
@@ -47,7 +47,7 @@
   <h4>Example:</h4>
   <p class="code">var _fric = physics_get_friction(fix_id);<br />
     physics_set_friction(fix_id, _fric + 0.1);</p>
-  <p>The code above gets the current friction value for the bound physics properties of the instance and then sets them to a different value.</p>
+  <p>The code above gets the current friction value for the bound physics properties of the instance and then sets it to a different value.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
@@ -57,7 +57,7 @@
         <div style="float:right">Next: <a href="physics_set_density.htm">physics_set_density</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_set_friction

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_set_restitution.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_set_restitution.htm
@@ -30,13 +30,13 @@
       </tr>
       <tr>
         <td>fixture</td>
-        <td><span data-keyref="Type_ID_PhyFixture"><a href="physics_fixture_create.htm" target="_blank">Physics Fixture ID</a></span></td>
-        <td>the ID of the bound fixture</td>
+        <td><span data-keyref="Type_ID_PhyFixtureBound"><a href="physics_fixture_bind.htm" target="_blank">Physics Bound Fixture ID</a></span></td>
+        <td>The ID of the bound fixture</td>
       </tr>
       <tr>
         <td>restitution</td>
         <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
-        <td>the new restitution value to apply</td>
+        <td>The new restitution value to apply</td>
       </tr>
     </tbody>
   </table>
@@ -47,7 +47,7 @@
   <h4>Example:</h4>
   <p class="code">var _rest = physics_get_restitution(fix_id);<br />
     physics_set_restitution(fix_id, _rest * 2);</p>
-  <p>The code above gets the current restitution value for the bound physics properties of the instance and then sets them to a different value.</p>
+  <p>The code above gets the current restitution value for the bound physics properties of the instance and then sets it to a different value.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
@@ -57,7 +57,7 @@
         <div style="float:right">Next: <a href="physics_fixture_create.htm">physics_fixture_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_set_restitution

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/Joints.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/Joints.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>Joints</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../../assets/css/default.css" type="text/css" />
   <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -14,45 +14,44 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>Joints</h1>
+  <h1><span data-field="title" data-format="default">Joints</span></h1>
   <p>In the <span data-keyref="GameMaker Name">GameMaker</span> physics world, joints are used to constrain instances to the world or to each other. Typical examples in games include ragdolls, teeters, and pulleys, but joints can be combined in many different ways to create interesting motions or add realism to your game world.</p>
-  <p class="note"><b>NOTE</b>: A joint does not need to be deleted when you destroy an instance joined to another instance, nor does it need to be deleted at the end of a room. Except in very specific cases (see the <a href="physics_joint_gear_create.htm">gear joint</a>) as this is dealt with automatically by <span data-keyref="GameMaker Name">GameMaker</span>.</p>
+  <p class="note"><span data-conref="../../../../assets/snippets/Tag_note.hts"> </span> A joint does not need to be deleted when you destroy an instance joined to another instance, nor does it need to be deleted at the end of a room. Except in very specific cases (see the <a href="physics_joint_gear_create.htm">gear joint</a>) as this is dealt with automatically by <span data-keyref="GameMaker Name">GameMaker</span>.</p>
   <p>The following pages explain the available joints and how they can be created:</p>
   <ul class="colour">
-    <li><a href="physics_joint_distance_create.htm">physics_joint_distance_create</a></li>
-    <li><a href="physics_joint_revolute_create.htm">physics_joint_revolute_create</a></li>
-    <li><a href="physics_joint_prismatic_create.htm">physics_joint_prismatic_create</a></li>
-    <li><a href="physics_joint_pulley_create.htm">physics_joint_pulley_create</a></li>
-    <li><a href="physics_joint_gear_create.htm">physics_joint_gear_create</a></li>
-    <li><a href="physics_joint_rope_create.htm">physics_joint_rope_create</a></li>
-    <li><a href="physics_joint_wheel_create.htm">physics_joint_wheel_create</a></li>
-    <li><a href="physics_joint_weld_create.htm">physics_joint_weld_create</a></li>
-    <li><a href="physics_joint_friction_create.htm">physics_joint_friction_create</a></li>
-    <li><a href="physics_joint_delete.htm">physics_joint_delete</a></li>
+    <li><a data-xref="{title}" href="physics_joint_distance_create.htm">physics_joint_distance_create</a></li>
+    <li><a data-xref="{title}" href="physics_joint_revolute_create.htm">physics_joint_revolute_create</a></li>
+    <li><a data-xref="{title}" href="physics_joint_prismatic_create.htm">physics_joint_prismatic_create</a></li>
+    <li><a data-xref="{title}" href="physics_joint_pulley_create.htm">physics_joint_pulley_create</a></li>
+    <li><a data-xref="{title}" href="physics_joint_gear_create.htm">physics_joint_gear_create</a></li>
+    <li><a data-xref="{title}" href="physics_joint_rope_create.htm">physics_joint_rope_create</a></li>
+    <li><a data-xref="{title}" href="physics_joint_wheel_create.htm">physics_joint_wheel_create</a></li>
+    <li><a data-xref="{title}" href="physics_joint_weld_create.htm">physics_joint_weld_create</a></li>
+    <li><a data-xref="{title}" href="physics_joint_friction_create.htm">physics_joint_friction_create</a></li>
+    <li><a data-xref="{title}" href="physics_joint_delete.htm">physics_joint_delete</a></li>
   </ul>
   <p> </p>
   <p>Once a joint has been created, it can often be necessary to know its properties in order to change them at specific times in your game. The following functions (with their corresponding internal constants) are available to test and change joint values:</p>
   <ul class="colour">
-    <li><a href="physics_joint_enable_motor.htm">physics_joint_enable_motor</a></li>
-    <li><a href="physics_joint_get_value.htm">physics_joint_get_value</a></li>
-    <li><a href="physics_joint_set_value.htm">physics_joint_set_value</a></li>
+    <li><a data-xref="{title}" href="physics_joint_enable_motor.htm">physics_joint_enable_motor</a></li>
+    <li><a data-xref="{title}" href="physics_joint_get_value.htm">physics_joint_get_value</a></li>
+    <li><a data-xref="{title}" href="physics_joint_set_value.htm">physics_joint_set_value</a></li>
   </ul>
   <p> </p>
   <p>Additionally, you can use a number of constants from within <span data-keyref="GameMaker Name">GameMaker</span> functions to get (or set) different properties of certain joints. These constants can all be found in the following section:</p>
   <ul class="colour">
-    <li><a href="Physics_Joint_Constants.htm">Physics Joint Constants</a></li>
+    <li><a data-xref="{title}" href="Physics_Joint_Constants.htm">Physics Joint Constants</a></li>
   </ul>
-  <p> </p>
   <p> </p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="../Physics.htm">Physics</a></div>
-        <div style="float:right">Next: <a href="../Soft_Body_Particles/Soft_Body_Particles.htm">Soft Body Particles</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="../Physics.htm">Physics</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="../Soft_Body_Particles/Soft_Body_Particles.htm">Soft Body Particles</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 Joints

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/Physics_Joint_Constants.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/Physics_Joint_Constants.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>Physics Joint Constants</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../../assets/css/default.css" type="text/css" />
   <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -14,15 +14,14 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>Physics Joint Constants</h1>
+  <h1><span data-field="title" data-format="default">Physics Joint Constants</span></h1>
   <p>There are a great number of constants included within the <span data-keyref="GameMaker Name">GameMaker</span> GML that are specific to <i>joints</i> between fixtures in the physics world. These can be used in conjunction with many of the different joint functions to set or get information from them in real time while the physics simulation is running. You should be aware, however, that complex calculations are done when you call these, so they should be used with care and only when necessary and note that <i>many are unique to a specific type of joint</i>. Also note that while you can get all these values with the appropriate function, you can only set those that are marked as not being read-only.</p>
   <p>In general these constants would be used in conjunction with the following functions:</p>
   <ul class="colour">
-    <li><a href="physics_joint_get_value.htm">physics_joint_get_value</a></li>
-    <li><a href="physics_joint_set_value.htm">physics_joint_set_value</a></li>
+    <li><a data-xref="{title}" href="physics_joint_get_value.htm">physics_joint_get_value</a></li>
+    <li><a data-xref="{title}" href="physics_joint_set_value.htm">physics_joint_set_value</a></li>
   </ul>
-  <p> </p>
-  <h2><label for="one">General</label></h2>
+  <h2>General</h2>
   <p>The following constants can be applied to any of the available joint types:</p>
   <table>
     <colgroup>
@@ -32,7 +31,7 @@
     </colgroup>
     <tbody>
       <tr>
-        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a data-rhwidget="HyperlinkPopover" href="../../../../../GameMaker_Language/GML_Reference/Physics/Joints/Physics_Joint_Constants.htm">Physics Joint Constant</a></span></th>
+        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a href="Physics_Joint_Constants.htm" target="_blank">Physics Joint Constant</a></span></th>
       </tr>
       <tr>
         <th>Constant</th>
@@ -76,14 +75,12 @@
       </tr>
     </tbody>
   </table>
-  <h2><br />
-    <label for="two">Motors</label>
-  </h2>
+  <h2>Motors</h2>
   <p>These constants are for those joints that have a <i>motor</i> attached to them (revolute, prismatic, wheel):</p>
   <table>
     <tbody>
       <tr>
-        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a data-rhwidget="HyperlinkPopover" href="../../../../../GameMaker_Language/GML_Reference/Physics/Joints/Physics_Joint_Constants.htm">Physics Joint Constant</a></span></th>
+        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a href="Physics_Joint_Constants.htm" target="_blank">Physics Joint Constant</a></span></th>
       </tr>
       <tr>
         <th>Constant</th>
@@ -117,9 +114,7 @@
       </tr>
     </tbody>
   </table>
-  <h2><br />
-    <label for="three">Revolute Joints</label>
-  </h2>
+  <h2>Revolute Joints</h2>
   <p>For a revolute joint you can use the following constant (as well as the <i>motor</i> constants if one has been added):</p>
   <table>
     <colgroup>
@@ -129,7 +124,7 @@
     </colgroup>
     <tbody>
       <tr>
-        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a data-rhwidget="HyperlinkPopover" href="../../../../../GameMaker_Language/GML_Reference/Physics/Joints/Physics_Joint_Constants.htm">Physics Joint Constant</a></span></th>
+        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a href="Physics_Joint_Constants.htm" target="_blank">Physics Joint Constant</a></span></th>
       </tr>
       <tr>
         <th>Constant</th>
@@ -144,7 +139,7 @@
       </tr>
       <tr>
         <td><span class="inline">phy_joint_angle_limits</span></td>
-        <td style="">Enable or disable angle limiting for the joint. Set the value to <span class="inline">true</span> to enable or <span class="inline">false</span> to disable.</td>
+        <td style="">Enable or disable angle limiting for the joint. Set the value to <span class="inline2">true</span> to enable or <span class="inline2">false</span> to disable.</td>
         <td style="">No</td>
       </tr>
       <tr>
@@ -159,14 +154,12 @@
       </tr>
     </tbody>
   </table>
-  <h2><br />
-    <label for="four">Prismatic Joints</label>
-  </h2>
+  <h2>Prismatic Joints</h2>
   <p>For a prismatic joint you can use the following constant:</p>
   <table>
     <tbody>
       <tr>
-        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a data-rhwidget="HyperlinkPopover" href="../../../../../GameMaker_Language/GML_Reference/Physics/Joints/Physics_Joint_Constants.htm">Physics Joint Constant</a></span></th>
+        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a href="Physics_Joint_Constants.htm" target="_blank">Physics Joint Constant</a></span></th>
       </tr>
       <tr>
         <th>Constant</th>
@@ -175,7 +168,7 @@
       </tr>
       <tr>
         <td><span class="inline">phy_joint_translation</span></td>
-        <td>Gets the distance between the anchor x/y coordinates and the local x/y coordinates.</td>
+        <td>The distance between the anchor x/y coordinates and the local x/y coordinates.</td>
         <td>Yes</td>
       </tr>
       <tr>
@@ -185,9 +178,7 @@
       </tr>
     </tbody>
   </table>
-  <h2><br />
-    <label for="six">Distance Joints, Weld Joints and Wheel Joints</label>
-  </h2>
+  <h2>Distance Joints, Weld Joints and Wheel Joints</h2>
   <p>For a distance, weld, and wheel joints you can use the following constants (as well as those for pulley joints):</p>
   <table>
     <colgroup>
@@ -197,7 +188,7 @@
     </colgroup>
     <tbody>
       <tr>
-        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a data-rhwidget="HyperlinkPopover" href="../../../../../GameMaker_Language/GML_Reference/Physics/Joints/Physics_Joint_Constants.htm">Physics Joint Constant</a></span></th>
+        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a href="Physics_Joint_Constants.htm" target="_blank">Physics Joint Constant</a></span></th>
       </tr>
       <tr>
         <th>Constant</th>
@@ -211,7 +202,7 @@
       </tr>
       <tr>
         <td><span class="inline">phy_joint_frequency</span></td>
-        <td>This will return (or set) the oscillation frequency for the joint, in hertz, and typically the frequency should be less than a half the frequency of the time step, as set by the function <a href="../The_Physics_World/physics_world_update_speed.htm"><span class="inline">physics_world_update_speed()</span></a>.</td>
+        <td>This will return (or set) the oscillation frequency for the joint, in hertz, and typically the frequency should be less than a half the frequency of the time step, as set by the function <span class="inline3_func"><a data-xref="{title}" href="../The_Physics_World/physics_world_update_speed.htm">physics_world_update_speed</a></span>.</td>
         <td>No</td>
       </tr>
       <tr>
@@ -226,14 +217,12 @@
       </tr>
     </tbody>
   </table>
-  <h2><br />
-    <label for="seven">Friction Joints</label>
-  </h2>
+  <h2>Friction Joints</h2>
   <p>For a friction joint you can use the following constants:</p>
   <table>
     <tbody>
       <tr>
-        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a data-rhwidget="HyperlinkPopover" href="../../../../../GameMaker_Language/GML_Reference/Physics/Joints/Physics_Joint_Constants.htm">Physics Joint Constant</a></span></th>
+        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a href="Physics_Joint_Constants.htm" target="_blank">Physics Joint Constant</a></span></th>
       </tr>
       <tr>
         <th>Constant</th>
@@ -252,14 +241,12 @@
       </tr>
     </tbody>
   </table>
-  <h2><br />
-    <label for="eight">Rope Joints</label>
-  </h2>
+  <h2>Rope Joints</h2>
   <p>For a rope joint you can use the following constant:</p>
   <table>
     <tbody>
       <tr>
-        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a data-rhwidget="HyperlinkPopover" href="../../../../../GameMaker_Language/GML_Reference/Physics/Joints/Physics_Joint_Constants.htm">Physics Joint Constant</a></span></th>
+        <th colspan="3"><span data-keyref="Type_Constant_Phy_Joint"><a href="Physics_Joint_Constants.htm" target="_blank">Physics Joint Constant</a></span></th>
       </tr>
       <tr>
         <th>Constant</th>
@@ -282,7 +269,7 @@
         <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 Joints

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_delete.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_delete.htm
@@ -43,12 +43,12 @@
   <p class="code">var _reaction_force_x, _reaction_force_y, _reaction_force;<br />
     if (ship_joint)<br />
     {<br />
-        _<span class="misspell-word">reaction_force_x</span> = physics_joint_get_value(<span class="misspell-word">ship_joint</span>, phy_joint_reaction_force_x);<br />
-        _<span class="misspell-word">reaction_force_y</span> = physics_joint_get_value(<span class="misspell-word">ship_joint</span>, phy_joint_reaction_force_y);<br />
-        _reaction_force = sqrt((_<span class="misspell-word">reaction_force_x</span> + _<span class="misspell-word">reaction_force_x</span>) + (_<span class="misspell-word">reaction_force_y</span> + _<span class="misspell-word">reaction_force_y</span>));<br />
+        _reaction_force_x = physics_joint_get_value(ship_joint, phy_joint_reaction_force_x);<br />
+        _reaction_force_y = physics_joint_get_value(ship_joint, phy_joint_reaction_force_y);<br />
+        _reaction_force = sqrt((_reaction_force_x + _reaction_force_x) + (_reaction_force_y + _reaction_force_y));<br />
         if (_reaction_force &gt; 2)<br />
         {<br />
-            physics_joint_delete(<span class="misspell-word">ship_joint</span>);<br />
+            physics_joint_delete(ship_joint);<br />
             ship_joint = -1;<br />
         }<br />
     }</p>
@@ -58,11 +58,11 @@
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_enable_motor.htm">physics_joint_enable_motor</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_enable_motor.htm">physics_joint_enable_motor</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_delete

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_distance_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_distance_create.htm
@@ -17,8 +17,8 @@
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">physics_joint_distance_create</span></h1>
   <p>This function creates a distance joint between two physics instances.</p>
-  <p>One of the simplest joints is a distance joint which says that the distance between two points on two instances must be constant. When you specify a distance joint the two instances should already be created and have a fixture assigned, then you define the two anchor points in room coordinates. The first anchor point is connected to instance 1, the second anchor point is connected to instance 2 and the distance between these points imply the length of the distance constrain. The image below shows how this works:</p>
-  <p><img alt="Distance joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/direction_joint_image.png" />As you can see, the anchor points are specified as room coordinates so care must be taken when defining them, especially if the instances are being created at the same time as the joints rather than being placed in the room through the room editor. You should also realise that the joints are created independently of the size of the sprite of the instances or the fixtures they have attached. So, if you create a distance joint somewhere other than the origin of the instance, it is still valid and will constrain the two instances relative to the position at which it was created. If you set the &quot;col&quot; value to <span class="inline">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events, however if it is set to <span class="inline">false</span>, they will not collide no matter what.</p>
+  <p>One of the simplest joints is a distance joint which says that the distance between two points on two instances must be constant. When you specify a distance joint the two instances should already be created and have a fixture assigned, then you define the two anchor points in room coordinates. The first anchor point is connected to instance 1, the second anchor point is connected to instance 2 and the distance between these points implies the length of the distance constraint. The image below shows how this works:</p>
+  <p><img alt="Distance joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/direction_joint_image.png" />As you can see, the anchor points are specified as room coordinates so care must be taken when defining them, especially if the instances are being created at the same time as the joints rather than being placed in the room through the Room Editor. You should also realise that the joints are created independently of the size of the sprite of the instances or the fixtures they have attached. So, if you create a distance joint somewhere other than the origin of the instance, it is still valid and will constrain the two instances relative to the position at which it was created. If you set the <span class="inline2">col</span> value to <span class="inline2">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events. If it is set to <span class="inline2">false</span>, however, they will not collide no matter what.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_distance_create</span>(inst1, inst2, w_anchor1_x, w_anchor1_y, w_anchor2_x, w_anchor2_y, col)</p>
@@ -57,12 +57,12 @@
       <tr>
         <td>w_anchor2_y</td>
         <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
-        <td>the second y coordinate for the joint, within the game world</td>
+        <td>The second y coordinate for the joint, within the game world</td>
       </tr>
       <tr>
         <td>col</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the two instances can collide (true) or not (false)</td>
+        <td>Whether the two instances can collide (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
     </tbody>
   </table>
@@ -82,15 +82,14 @@
   <p>The above code creates and defines a new fixture and then creates an instance of &quot;obj_Rudder&quot;. The fixture is then assigned to the instance that is running the code as well as the newly created one and a joint is created between them. Finally the fixture is deleted as it is no longer needed.</p>
   <p> </p>
   <p> </p>
-  <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_revolute_create.htm">physics_joint_revolute_create</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_revolute_create.htm">physics_joint_revolute_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_distance_create

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_enable_motor.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_enable_motor.htm
@@ -16,7 +16,7 @@
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">physics_joint_enable_motor</span></h1>
   <p>This function sets whether to enable or disable the motor on a physics joint that has a motor.</p>
-  <p>When you have a joint with a motor (<a href="physics_joint_prismatic_create.htm">prismatic</a> or <a href="physics_joint_revolute_create.htm">revolute</a>), you may want to be able to switch the motor on or off depending on variables and conditions within the game. For this, you need to have stored the index of the joint previously in a variable and then you can switch the motor on or off by using this function and setting the &quot;motor&quot; argument to <span class="inline">true</span> or <span class="inline">false</span>.</p>
+  <p>When you have a joint with a motor (<a href="physics_joint_prismatic_create.htm">prismatic</a> or <a href="physics_joint_revolute_create.htm">revolute</a>), you may want to be able to switch the motor on or off depending on variables and conditions within the game. For this, you need to have stored the index of the joint previously in a variable and then you can switch the motor on or off by using this function and setting the &quot;motor&quot; argument to <span class="inline2">true</span> or <span class="inline2">false</span>.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_enable_motor</span>(joint, motor)</p>
@@ -35,7 +35,7 @@
       <tr>
         <td>motor</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether you wish to turn the motor on (true) or off (false)</td>
+        <td>Whether you wish to turn the motor on (<span class="inline2">true</span>) or off (<span class="inline2">false</span>)</td>
       </tr>
     </tbody>
   </table>
@@ -58,15 +58,14 @@
   <p>The above code creates and defines a new fixture and then creates an instance of &quot;obj_Door&quot;, binding the created fixture to the two instances. They are then joined by a revolute joint with no motor and the angles limited to a +/- 90 degree swing, and we store the joint index in the variable &quot;perma_joint&quot;. We then switch the motor on using this variable, before finally deleting the fixture from memory as it is no longer needed.</p>
   <p> </p>
   <p> </p>
-  <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_get_value.htm">physics_joint_get_value</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_get_value.htm">physics_joint_get_value</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_enable_motor

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_friction_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_friction_create.htm
@@ -18,7 +18,7 @@
   <h1><span data-field="title" data-format="default">physics_joint_friction_create</span></h1>
   <p>This function creates a friction joint between two physics instances.</p>
   <p>The friction joint is a bit different to all other joints in the physics simulation in that the connection created will not constrain the instances&#39; position or movement, but rather their speed and rotation. This works by taking the maximum input values for force and torque and applying those to the second fixture to bring the speed and angular momentum down to the same values as that of the first instance. So, if you have a stationary instance and a moving instance then connect them with a friction joint, the moving instance will gradually slow down until it too is stationary. If both instances were moving then the second instance will have its movement speed modified to match that of the first instance.</p>
-  <p><img alt="Friction joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/friction_joint_image.png" />As with most other joints, you supply the instances to join together, as well as the position for the joint to be created at within the room. You then supply the maximum force and maximum torque (directional and rotational friction), and if you set the &quot;col&quot; value to <span class="inline">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events, however if it is set to <span class="inline">false</span>, they will not collide no matter what.</p>
+  <p><img alt="Friction joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/friction_joint_image.png" />As with most other joints, you supply the instances to join together, as well as the position for the joint to be created at within the room. You then supply the maximum force and maximum torque (directional and rotational friction), and if you set the <span class="inline2">col</span> value to <span class="inline2">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events. If it is set to <span class="inline2">false</span>, however, they will not collide no matter what.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_friction_create</span>(inst1, inst2, anchor_x, anchor_y, max_force, max_torque, col)</p>
@@ -62,7 +62,7 @@
       <tr>
         <td>col</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the two instances can collide (true) or not (false)</td>
+        <td>Whether the two instances can collide (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
     </tbody>
   </table>
@@ -82,15 +82,14 @@
   <p>The above code will create a fixture then bind it to two instances, before connecting them both using a friction joint.</p>
   <p> </p>
   <p> </p>
-  <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_delete.htm">physics_joint_delete</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_delete.htm">physics_joint_delete</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_friction_create

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_gear_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_gear_create.htm
@@ -18,8 +18,8 @@
   <h1><span data-field="title" data-format="default">physics_joint_gear_create</span></h1>
   <p>This function creates a gear joint between two physics instances.</p>
   <p>If you want to create a sophisticated mechanical contraption you might want to use gears. In principle you can create gears in <span data-keyref="GameMaker Name">GameMaker</span> by using compounding instances to model gear teeth, but this is not very efficient and might be tedious to author! Thankfully there is a simpler method, and that is to use a <i>gear joint</i>. To make one you need to have previously defined your fixtures and created the two basic joints that are going to comprise your gear - these <b>must</b> be made up of one <a href="physics_joint_revolute_create.htm">revolute joint</a> and either a <a href="physics_joint_prismatic_create.htm">prismatic joint</a> or another <i>revolute joint</i>. The image below shows how a gear would typically be created in a game:</p>
-  <p><img alt="Gear joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/gear_joint_image.png" />So what happens? Well, once the two joints are added into the gear, interaction with one will have an effect on the other, so in the example image above, if you rotate inst2, inst3 will move up and down, or if you move inst3 up and down then inst2 will rotate. You can also change the gear ratio, meaning that you need to move one instance more (or less) to get the desired effect. The code in the example at the bottom shows how something like the image above can be created.</p>
-  <p class="note"><span data-conref="../../../../assets/snippets/Tag_note.hts"> </span> If you need to delete either of the two instances that are involved in the gear joint (or just delete their joints) then you <b>must</b> delete the gear joint first using <span style="font-size:1px;"><a href="physics_joint_delete.htm"><span class="inline">physics_joint_delete()</span></a></span> or else you will get an error!</p>
+  <p><img alt="Gear joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/gear_joint_image.png" />So what happens? Well, once the two joints are added into the gear, interaction with one will have an effect on the other, so in the example image above, if you rotate <span class="inline2">inst2</span>, <span class="inline2">inst3</span> will move up and down, or if you move <span class="inline2">inst3</span> up and down then <span class="inline2">inst2</span> will rotate. You can also change the gear ratio, meaning that you need to move one instance more (or less) to get the desired effect. The code in the example at the bottom shows how something like the image above can be created.</p>
+  <p class="note"><span data-conref="../../../../assets/snippets/Tag_note.hts"> </span> If you need to delete either of the two instances that are involved in the gear joint (or just delete their joints) then you <b>must</b> delete the gear joint first using <span class="inline3_func"><a data-xref="{title}" href="physics_joint_delete.htm">physics_joint_delete</a></span> or else you will get an error!</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_gear_create</span>(inst1, inst2, joint_1, joint_2, ratio)</p>
@@ -78,18 +78,17 @@
     p_joint = physics_joint_prismatic_create(inst1, inst3, 150, room_height - 300, 0, 1, -10, 10, true, 0, 0, 0, 0);<br />
     <span data-field="title" data-format="default">physics_joint_gear_create</span>(inst2, inst3, r_joint, p_joint, 0.5);
   </p>
-  <p>The above code creates and defines two fixture and then creates three instances, one &quot;obj_Ground&quot; and two others, &quot;obj_Cog&quot; and &quot;obj_Barrel&quot;. The fixtures are then bound to these instances and two joints are created. A revolute joint between the ground and the cog, and a prismatic joint between the ground and the barrel. Finally a gear joint is created between the cog and barrel instances using the previously defined revolute and prismatic joints.</p>
-  <p> </p>
+  <p>The above code creates and defines two fixture and then creates three instances, one &quot;obj_Ground&quot; and two others, &quot;obj_Cog&quot; and &quot;obj_Barrel&quot;. The fixtures are then bound to these instances and two joints are created: a revolute joint between the ground and the cog, and a prismatic joint between the ground and the barrel. Finally a gear joint is created between the cog and barrel instances using the previously defined revolute and prismatic joints.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_rope_create.htm">physics_joint_rope_create</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_rope_create.htm">physics_joint_rope_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_gear_create

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_get_value.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_get_value.htm
@@ -17,7 +17,7 @@
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">physics_joint_get_value</span></h1>
   <p>This function returns the value of the joint property corresponding to the given joint constant.</p>
-  <p>By using a series of predefined constants, you can ask <span data-keyref="GameMaker Name">GameMaker</span> to tell you a number of things about the state of any given joint. This is very useful as it gives you the ability to delete joints or change an instances behaviour depending on whatever your needs are at the time. There are a number of constants that can be used in this function and they can be found here: <a href="Physics_Joint_Constants.htm">Physics Joint Constants</a>, but be aware that complex calculations are done when you call these, so they should be used with care and only when necessary and note that <i>many are unique to a specific type of joint</i>.</p>
+  <p>By using a series of predefined constants, you can ask <span data-keyref="GameMaker Name">GameMaker</span> to tell you a number of things about the state of any given joint. This is very useful as it gives you the ability to delete joints or change an instance&#39;s behaviour depending on whatever your needs are at the time. There are a number of constants that can be used in this function and they can be found here: <a data-xref="{title}" href="Physics_Joint_Constants.htm">Physics Joint Constants</a>, but be aware that complex calculations are done when you call these, so they should be used with care and only when necessary. Also note that <i>many are unique to a specific type of joint</i>.</p>
   <p>If the property does not exist (if, for example, you check a pulley joint for prismatic translation) then 0 will be the return value.</p>
   <p> </p>
   <h4>Syntax:</h4>
@@ -60,15 +60,14 @@
   <p>The above code checks to see if the variable &quot;shipJoint&quot; holds a joint index and if it does, it then calculates the force being applied to that joint using the two constants. Finally, if the total force is greater than 2, the joint is deleted.</p>
   <p> </p>
   <p> </p>
-  <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_set_value.htm">physics_joint_set_value</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_set_value.htm">physics_joint_set_value</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_get_value

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_prismatic_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_prismatic_create.htm
@@ -18,9 +18,9 @@
   <h1><span data-field="title" data-format="default">physics_joint_prismatic_create</span></h1>
   <p>This function creates a prismatic joint between two physics instances.</p>
   <p>Like a revolute joint, the prismatic joint only has one degree of freedom, but with this joint it is directional relative to an axis rather than rotational and actually prevents any form of rotation. Here is an image to help you visualise how this works:</p>
-  <p><img alt="Prismatic joint anchor points illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/prismatic_joint_image_1.png" />We have two instances joined at the anchor point, with an axis for movement defined from the vector the two w_axis x/y coordinates relative to the (0, 0) coordinates of the physics world (so an x component of 0 and a y component of 1 (0, 1) would make the joint a vertical prismatic joint). This joint can then <i>only</i> move relative to this axis, like a spring or a piston. If you set the lower or upper trans limit, you are basically limiting the amount of movement along this axis, where the 0 position is the exact spot that you defined with w_anchor x/y, so a negative value would go to the &quot;left&quot; of that point along the axis and a positive value to the &quot;right&quot; as shown in the following diagram (realise that &quot;left&quot; and &quot;right&quot; are relative terms!):</p>
-  <p><img alt="Prismatic joint limits illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/prismatic_joint_image_2.png" />You can also define the joint as having a motor or not. This means that when un-influenced by a collision the joint will move in a direction along the axis. this direction is defined by the motor speed, with a positive number being towards the axis coordinates (&quot;right&quot;) and a negative number being towards the anchor point (&quot;left&quot;). The &quot;max_motor_force&quot; argument is for limiting the speed of the movement so that you don&#39;t get a perpetually accelerating motor and to limit the influence that a collision may have on the movement. In this way you can use a joint motor to simulate joint friction by setting the joint speed to zero and maximum force to some small, but significant value. The motor will try to prevent the joint from moving, but will yield to a significant load.</p>
-  <p>As with all the joints, if you set the &quot;col&quot; value to <span class="inline">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events, however if it is set to <span class="inline">false</span>, they will not collide no matter what.</p>
+  <p><img alt="Prismatic joint anchor points illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/prismatic_joint_image_1.png" />We have two instances joined at the anchor point, with an axis for movement defined from the vector the <span class="inline2">w_axis_x</span>/<span class="inline2">w_axis_y</span> coordinates relative to the (0, 0) coordinates of the physics world (so an x component of 0 and a y component of 1 (0, 1) would make the joint a vertical prismatic joint). This joint can then <i>only</i> move relative to this axis, like a spring or a piston. If you set the lower or upper trans limit, you are basically limiting the amount of movement along this axis, where the 0 position is the exact spot that you defined with <span class="inline2">w_anchor_x</span>/<span class="inline2">w_anchor_y</span>, so a negative value would go to the &quot;left&quot; of that point along the axis and a positive value to the &quot;right&quot; as shown in the following diagram (realise that &quot;left&quot; and &quot;right&quot; are relative terms!):</p>
+  <p><img alt="Prismatic joint limits illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/prismatic_joint_image_2.png" />You can also define the joint as having a motor or not. This means that when un-influenced by a collision the joint will move in a direction along the axis. this direction is defined by the motor speed, with a positive number being towards the axis coordinates (&quot;right&quot;) and a negative number being towards the anchor point (&quot;left&quot;). The <span class="inline2">max_motor_force</span> argument is for limiting the speed of the movement so that you don&#39;t get a perpetually accelerating motor and to limit the influence that a collision may have on the movement. In this way you can use a joint motor to simulate joint friction by setting the joint speed to zero and maximum force to some small, but significant value. The motor will try to prevent the joint from moving, but will yield to a significant load.</p>
+  <p>As with all the joints, if you set the <span class="inline2">col</span> value to <span class="inline2">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events. If it is set to <span class="inline2">false</span>, however, they will not collide no matter what.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_prismatic_create</span>(inst1, inst2, w_anchor_x, w_anchor_y, w_axis_x, w_axis_x, lower_trans_limit, upper_trans_limit, limit, max_motor_force, motor_speed, motor, col)</p>
@@ -74,7 +74,7 @@
       <tr>
         <td>limit</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether to limit the movement of the joint (true) or not (false)</td>
+        <td>Whether to limit the movement of the joint (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
       <tr>
         <td>max_motor_force</td>
@@ -89,12 +89,12 @@
       <tr>
         <td>motor</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the motor should be active (true) or not (false)</td>
+        <td>Whether the motor should be active (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
       <tr>
         <td>col</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the two instances can collide (true) or not (false)</td>
+        <td>Whether the two instances can collide (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
     </tbody>
   </table>
@@ -114,15 +114,14 @@
   <p>The above code creates and defines a new fixture and then creates an instance of &quot;obj_Piston&quot;, binding the created fixture to the two new objects. They are then joined by a prismatic joint with the anchor position at the same x/y coordinates of the first instance and an axis formed by the vector of the x/y position and the axis x/y (in this case 0,10, which is &quot;down&quot;). There are no limits placed on the amount of movement along this axis, but we have added a motor with 0 speed and a maximum force of 5 to simulate joint friction.</p>
   <p> </p>
   <p> </p>
-  <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_pulley_create.htm">physics_joint_pulley_create</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_pulley_create.htm">physics_joint_pulley_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_prismatic_create

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_pulley_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_pulley_create.htm
@@ -17,9 +17,9 @@
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">physics_joint_pulley_create</span></h1>
   <p>This function creates a pulley joint between two physics instances.</p>
-  <p>The pulley joint is used to connect two instances within the physics world in such a way that moving one will directly influence the movement of the other. These joints are first anchored in the world space at two points, each one connected to an instance at its center of mass. This can be changed by setting the local anchor x/y coordinates relative to the origin of the instance, meaning that the actual connection from the instance to the physics world anchor point can be offset somewhere other than its origin. The following image illustrates this:</p>
-  <p><img alt="Pulley joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/pulley_joint_image.png" />If you look at inst2 you can see that its local anchor point has been offset 20 pixels to the &quot;left&quot; of its origin (Remember! The world anchor points are defined using the room coordinates, while the local anchor points are defined relative to the origin of the instance). You can also specify a ratio for the pulley joint, which tells one side or the other to move faster, with a value below 1 making the first instance move faster (E.G. 0.5 will make it move twice as fast) and a value above 1 making the second instance move faster (E.G. 2 will make it move twice as fast).</p>
-  <p>As with all the joints, if you set the &quot;col&quot; value to <span class="inline">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events, however if it is set to <span class="inline">false</span>, they will not collide no matter what.</p>
+  <p>The pulley joint is used to connect two instances within the physics world in such a way that moving one will directly influence the movement of the other. These joints are first anchored in the world space at two points, each one connected to an instance at its centre of mass. This can be changed by setting the local anchor x/y coordinates relative to the origin of the instance, meaning that the actual connection from the instance to the physics world anchor point can be offset somewhere other than its origin. The following image illustrates this:</p>
+  <p><img alt="Pulley joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/pulley_joint_image.png" />If you look at inst2 you can see that its local anchor point has been offset 20 pixels to the &quot;left&quot; of its origin (Remember! The world anchor points are defined using the room coordinates, while the local anchor points are defined relative to the origin of the instance). You can also specify a ratio for the pulley joint, which tells one side or the other to move faster, with a value below 1 making the first instance move faster (e.g. 0.5 will make it move twice as fast) and a value above 1 making the second instance move faster (e.g. 2 will make it move twice as fast).</p>
+  <p>As with all the joints, if you set the <span class="inline2">col</span> value to <span class="inline2">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events. If it is set to <span class="inline2">false</span>, however, they will not collide no matter what.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_pulley_create</span>(inst1, inst2, w_anchor1_x, w_anchor1_y, w_anchor2_x, w_anchor2_y, l_anchor1_x, l_anchor1_y, l_anchor2_x, l_anchor2_y, ratio, col)</p>
@@ -88,7 +88,7 @@
       <tr>
         <td>col</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the two instances can collide (true) or not (false)</td>
+        <td>Whether the two instances can collide (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
     </tbody>
   </table>
@@ -100,24 +100,23 @@
   <p class="code">var t_fix, inst1, inst2;<br />
     t_fix = physics_fixture_create();<br />
     physics_fixture_set_circle_shape(t_fix, 20);<br />
-    inst1 = instance_create_layer(150, room_height - 90, &quot;Instances&quot;, obj_Block);<br />
+    inst1 = instance_create_layer(150, room_height - 90, &quot;Instances&quot;, obj_block);<br />
     inst2 = instance_create_layer(300, room_height - 90, &quot;Instances&quot;, obj_block);<br />
     physics_fixture_bind(t_fix, inst1);<br />
     physics_fixture_bind(t_fix, inst2);<br />
     physics_joint_pulley_create(inst1, inst2, 150, room_height - 140, 300, room_height - 140, 0, 0, 0, 0, 2, 0);<br />
     physics_fixture_delete(t_fix);</p>
-  <p>The above code creates and defines a new fixture, creates two instances of &quot;obj_Block&quot;, and then binds this fixture two them. It then goes on to define a pulley joint between these instance, with no offset for the joints, a ratio of 2:1 (meaning that inst2 will move faster). No collisions occur between the two instances in the pulley.</p>
-  <p> </p>
+  <p>The above code creates and defines a new fixture, creates two instances of &quot;obj_block&quot;, and then binds this fixture two them. It then goes on to define a pulley joint between these instance, with no offset for the joints, a ratio of 2:1 (meaning that inst2 will move faster). No collisions occur between the two instances in the pulley.</p>
   <p> </p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_gear_create.htm">physics_joint_gear_create</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_gear_create.htm">physics_joint_gear_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_pulley_create

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_revolute_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_revolute_create.htm
@@ -18,9 +18,9 @@
   <h1><span data-field="title" data-format="default">physics_joint_revolute_create</span></h1>
   <p>This function creates a revolute joint between two physics instances.</p>
   <p>A revolute joint forces two bodies to share a common anchor point (often called a hinge point) and the joint has a single degree of freedom - the relative rotation of the two bodies around this point. To specify a revolute you need to provide two instances and a single anchor point in the room, as you can see in the image provided:</p>
-  <p><img alt="Revolute joint anchor points illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/revolute_joint_image_1.png" />If you look at the image, you can see that the two instances have been created to overlap and at the point where they are touching, we have defined a revolute joint. Now, this joint can be limited in its freedom of rotation thanks to the &quot;ang_min_limit&quot; and &quot;ang_max_limit&quot; values. How does this work? Well, let&#39;s look at another image:</p>
-  <p><img alt="Revolute joint angle limits illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/revolute_joint_image_2.png" />As you can see, angles in the physics world are <i>not</i> the same as the standard <span data-keyref="GameMaker Name">GameMaker</span> angles where right is 0 degrees and then it goes anti-clockwise so that up is 90, left is 180, and down is 270. No, when dealing with the revolute joint, the 0 degrees axis runs from the joint position to the origin of the second instance defined by the function and the angles are then calculated in a clockwise direction. If you switch on angle limiting, the limits are defined as being relative to this 0 degree axis and the limit range <i>should include zero</i>, otherwise the joint will lurch when the room begins. Finally, you can define the joint as having a motor or not. This means that when uninfluenced by a collision the joint will move in a direction, which is defined by the motor speed with a positive number being clockwise and a negative number being anti-clockwise. The &quot;max_motor_torque&quot; argument is for limiting the speed of the rotation so that you don&#39;t get a perpetually accelerating motor and to limit the influence that a collision may have on the rotation. In this way you can use a joint motor to simulate joint friction by setting joint speed to zero and maximum torque to some small, but significant value. The motor will try to prevent the joint from rotating, but will yield to a significant load.</p>
-  <p>As with all the joints, if you set the &quot;col&quot; value to <span class="inline">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events, however if it is set to <span class="inline">false</span>, they will not collide no matter what.</p>
+  <p><img alt="Revolute joint anchor points illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/revolute_joint_image_1.png" />If you look at the image, you can see that the two instances have been created to overlap and at the point where they are touching, we have defined a revolute joint. Now, this joint can be limited in its freedom of rotation thanks to the <span class="inline2">ang_min_limit</span> and <span class="inline2">ang_max_limit</span> values. How does this work? Well, let&#39;s look at another image:</p>
+  <p><img alt="Revolute joint angle limits illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/revolute_joint_image_2.png" />As you can see, angles in the physics world are <i>not</i> the same as the standard <span data-keyref="GameMaker Name">GameMaker</span> angles where right is 0 degrees and then it goes anti-clockwise so that up is 90, left is 180, and down is 270. No, when dealing with the revolute joint, the 0 degrees axis runs from the joint position to the origin of the second instance defined by the function and the angles are then calculated in a clockwise direction. If you switch on angle limiting, the limits are defined as being relative to this 0 degree axis and the limit range <i>should include zero</i>, otherwise the joint will lurch when the room begins. Finally, you can define the joint as having a motor or not. This means that when uninfluenced by a collision the joint will move in a direction, which is defined by the motor speed with a positive number being clockwise and a negative number being anti-clockwise. The <span class="inline2">max_motor_torque</span> argument is for limiting the speed of the rotation so that you don&#39;t get a perpetually accelerating motor and to limit the influence that a collision may have on the rotation. In this way you can use a joint motor to simulate joint friction by setting joint speed to zero and maximum torque to some small, but significant value. The motor will try to prevent the joint from rotating, but will yield to a significant load.</p>
+  <p>As with all the joints, if you set the <span class="inline2">col</span> value to <span class="inline2">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events. If it is set to <span class="inline2">false</span>, however, they will not collide no matter what.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_revolute_create</span>(inst1, inst2, w_anchor_x, w_anchor_y, ang_min_limt, ang_max_limit, ang_limit, max_motor_torque, motor_speed, motor, col)</p>
@@ -54,17 +54,17 @@
       <tr>
         <td>ang_min_limit</td>
         <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
-        <td>The lower permitted limit for the joint angle</td>
+        <td>The lower permitted limit for the joint angle, in degrees</td>
       </tr>
       <tr>
         <td>ang_max_limit</td>
         <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
-        <td>The upper permitted limit for the joint angle</td>
+        <td>The upper permitted limit for the joint angle, in degrees</td>
       </tr>
       <tr>
         <td>ang_limit</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the to limit the angle of the joint (true) or not (false)</td>
+        <td>Whether the to limit the angle of the joint (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
       <tr>
         <td>max_motor_torque</td>
@@ -79,12 +79,12 @@
       <tr>
         <td>motor</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the motor should be active (true) or not (false)</td>
+        <td>Whether the motor should be active (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
       <tr>
         <td>col</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the two instances can collide (true) or not (false)</td>
+        <td>Whether the two instances can collide (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
     </tbody>
   </table>
@@ -104,15 +104,14 @@
   <p>The above code creates and defines a new fixture and then creates an instance of &quot;obj_Door&quot;, binding the created fixture to the two new objects. They are then joined by a revolute joint with no motor and the angles limited to a +/- 90 degree swing. Finally the fixture is deleted as it is no longer needed.</p>
   <p> </p>
   <p> </p>
-  <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_prismatic_create.htm">physics_joint_prismatic_create</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_prismatic_create.htm">physics_joint_prismatic_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_revolute_create

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_rope_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_rope_create.htm
@@ -17,8 +17,8 @@
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">physics_joint_rope_create</span></h1>
   <p>This function creates a rope joint between two physics instances.</p>
-  <p>A rope joint is one which is used to join two instances that you want to keep a constant distance apart, no matter what other forces are acting on it. With a distance joint, you can get &quot;joint stretching&quot; where the two fixtures will separate and behave strangely should too much stress be put on the joint, however the rope joint does not do this and will not stretch any further than the maximum defined length. When you create a rope joint the two instances should already be created and have a fixture assigned, then you define the two anchor points in room coordinates. The first anchor point is connected to instance 1, the second anchor point is connected to instance 2 and the distance and the maxlength argument sets the maximum length constraint on the joint. The image below shows how this works:</p>
-  <p><img alt="Rope joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/direction_joint_image.png" />As you can see, the anchor points are specified as room coordinates so care must be taken when defining them, especially if the instances are being created at the same time as the joints rather than being placed in the room through the room editor. You should also realise that the joints are created independently of the size of the sprite of the instances or the fixtures they have attached. So, if you create a rope joint somewhere other than the origin of the instance, it is still valid and will constrain the two instances relative to the position at which it was created. If you set the &quot;col&quot; value to <span class="inline">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events, however if it is set to <span class="inline">false</span>, they will not collide no matter what.</p>
+  <p>A rope joint is one which is used to join two instances that you want to keep a constant distance apart, no matter what other forces are acting on it. With a distance joint, you can get &quot;joint stretching&quot; where the two fixtures will separate and behave strangely should too much stress be put on the joint. The rope joint, however, does not do this and will not stretch any further than the maximum defined length. When you create a rope joint the two instances should already be created and have a fixture assigned, then you define the two anchor points in room coordinates. The first anchor point is connected to instance 1, the second anchor point is connected to instance 2 and the distance and the <span class="inline2">maxlength</span> argument sets the maximum length constraint on the joint. The image below shows how this works:</p>
+  <p><img alt="Rope joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/direction_joint_image.png" />As you can see, the anchor points are specified as room coordinates so care must be taken when defining them, especially if the instances are being created at the same time as the joints rather than being placed in the room through the Room Editor. You should also realise that the joints are created independently of the size of the sprite of the instances or the fixtures they have attached. So, if you create a rope joint somewhere other than the origin of the instance, it is still valid and will constrain the two instances relative to the position at which it was created. If you set the <span class="inline2">col</span> value to <span class="inline2">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events. If it is set to <span class="inline2">false</span>, however, they will not collide no matter what.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_rope_create</span>(inst1, inst2, w_anchor1_x, w_anchor1_y, w_anchor2_x, w_anchor2_y, maxlength, col)</p>
@@ -67,7 +67,7 @@
       <tr>
         <td>col</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the two instances can collide (true) or not (false)</td>
+        <td>Whether the two instances can collide (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
     </tbody>
   </table>
@@ -87,15 +87,14 @@
   <p>The above code creates and defines a new fixture and then creates an instance of &quot;obj_Rudder&quot;. The fixture is then assigned to the instance that is running the code as well as the newly created one and a rope joint is created between them. Finally the fixture is deleted as it is no longer needed.</p>
   <p> </p>
   <p> </p>
-  <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_wheel_create.htm">physics_joint_wheel_create</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_wheel_create.htm">physics_joint_wheel_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_rope_create

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_set_value.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_set_value.htm
@@ -16,7 +16,7 @@
   <!--<div class="body-scroll" style="top: 150px;">-->
   <h1><span data-field="title" data-format="default">physics_joint_set_value</span></h1>
   <p>This function sets the value of the joint property corresponding to the given joint constant to the given value.</p>
-  <p>Certain joint properties can be changed and set even after the creation of the joint. There are a number of constants that can be used in this function and they can be found here: <a href="Physics_Joint_Constants.htm">Physics Joint Constants</a>.</p>
+  <p>Certain joint properties can be changed and set even after the creation of the joint. There are a number of constants that can be used in this function and they can be found here: <a data-xref="{title}" href="Physics_Joint_Constants.htm">Physics Joint Constants</a>.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_set_value</span>(joint, field, value)</p>
@@ -56,15 +56,14 @@
   <p>The above code checks to see if the joints maximum motor torque is set to less than 2 and if it is it then sets it to 2.</p>
   <p> </p>
   <p> </p>
-  <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_distance_create.htm">physics_joint_distance_create</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_distance_create.htm">physics_joint_distance_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_set_value

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_weld_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_weld_create.htm
@@ -103,7 +103,7 @@
     }</p>
   <p>The above code shows how to use a weld joint to connect multiple physics instances.</p>
   <p>In the Create event, a fixture is first created using and its shape is set to a 128 x 64 box shape. Then, a number of instances of an object <span class="inline2">obj_bridge_part</span> are created in a <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Language_Features/for.htm">for</a></span> loop. The fixture is bound to each new instance using <span class="inline3_func"><a data-xref="{title}" href="../Fixtures/physics_fixture_bind.htm">physics_fixture_bind</a></span> and all instances except the first one are connected to the previous one using a weld joint created with <span class="inline3_func"><span data-field="title" data-format="default">physics_joint_weld_create</span></span>. Finally, the fixture is deleted from memory.</p>
-  <p>In the Destroy event, all instances of <span class="inline2">obj_bridge_part</span> are destroyed and the previously bound fixtures with them. Note that the weld joints aren&#39;t destroyed as this is done automatically by <span data-keyref="GameMaker Name">GameMaker</span>.</p>
+  <p>In the Destroy event, all instances of <span class="inline2">obj_bridge_part</span> are destroyed and the previously bound fixtures with them. Note that the weld joints aren&#39;t deleted as this is done automatically by <span data-keyref="GameMaker Name">GameMaker</span>.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_weld_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_weld_create.htm
@@ -19,9 +19,9 @@
   <p>This function creates a weld joint between two physics instances.</p>
   <p>The weld joint is designed to attach two fixtures together in a strong, yet flexible bond. The weld joint will permit flexing between the two joined fixtures but without the stretching associated with, for example, a distance joint, and will always try to &quot;spring&quot; back to the reference angle when put under any stress or load.</p>
   <p>You define the point in the room where the joint should be created, as well as the angle that you wish the joint to try and maintain at all times, as shown in the image below:</p>
-  <p><img alt="Weld joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/weld_joint_image.png" />As you can see, the anchor points are specified as room coordinates so care must be taken when defining them, especially if the instances are being created at the same time as the joints rather than being placed in the room through the room editor. You should also realise that the joints are created independently of the size of the sprite of the instances or the fixtures they have attached. So, if you create a weld joint somewhere other than the origin of the instance, it is still valid and will constrain the two instances relative to the position at which it was created.</p>
+  <p><img alt="Weld joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/weld_joint_image.png" />As you can see, the anchor points are specified as room coordinates so care must be taken when defining them, especially if the instances are being created at the same time as the joints rather than being placed in the room through the Room Editor. You should also realise that the joints are created independently of the size of the sprite of the instances or the fixtures they have attached. So, if you create a weld joint somewhere other than the origin of the instance, it is still valid and will constrain the two instances relative to the position at which it was created.</p>
   <p>Since the weld joint is flexible and will bend and flex when under any stress, you can set the oscillation frequency (in Hz) as well as the damping ratio for the joint to get different effects - you may need to play with these values to fine tune them and it is recommended that you start off with smaller values and increment them until you get the effect that you desire.</p>
-  <p>If you set the &quot;col&quot; value to <span class="inline">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events, however if it is set to <span class="inline">false</span>, they will not collide no matter what.</p>
+  <p>If you set the <span class="inline2">col</span> value to <span class="inline2">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events. If it is set to <span class="inline2">false</span>, however, they will not collide no matter what.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_weld_create</span>(inst1, inst2, anchor_x, anchor_y, ref_angle, freq_hz, damping_ratio, col)</p>
@@ -55,7 +55,7 @@
       <tr>
         <td>ref_angle</td>
         <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
-        <td>The joint angle to maintain</td>
+        <td>The joint angle to maintain, in degrees</td>
       </tr>
       <tr>
         <td>freq_hz</td>
@@ -65,12 +65,12 @@
       <tr>
         <td>damping_ratio</td>
         <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
-        <td>This damping ratio for the joint</td>
+        <td>This is the damping ratio for the joint</td>
       </tr>
       <tr>
         <td>col</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the two instances can collide (true) or not (false)</td>
+        <td>Whether the two instances can collide (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
     </tbody>
   </table>
@@ -94,19 +94,18 @@
         }<br />
         p_id = o_id;<br />
     }<br />
-    physics-fixture_delete(fix);</p>
+    physics_fixture_delete(fix);</p>
   <p>The above code will create a fixture, then use a loop to create a number of instances, binding the fixture to each new instance and then joining them all together using a weld joint. Finally the fixture is deleted from memory.</p>
-  <p> </p>
   <p> </p>
   <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_friction_create.htm">physics_joint_friction_create</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_friction_create.htm">physics_joint_friction_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_weld_create

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_weld_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_weld_create.htm
@@ -79,23 +79,31 @@
   <p class="code"><span data-keyref="Type_ID_Physics_Joint"><a href="Joints.htm" target="_blank">Physics Joint ID</a></span></p>
   <p> </p>
   <h4>Example:</h4>
-  <p class="code">var i, fix, o_id, p_id;<br />
-    p_id = noone;<br />
-    o_id = noone;<br />
-    fix = physics_fixture_create();<br />
-    physics_fixture_set_box_shape(fix, 64, 32);<br />
-    for (i = 0; i &lt; 5; i++)<br />
+  <p class="code_heading">Create Event</p>
+  <p class="code">var _p_id = noone;<br />
+    var _o_id = noone;<br />
+    var _fix = physics_fixture_create();<br />
+    physics_fixture_set_box_shape(_fix, 64, 32);<br />
+    for (var i = 0; i &lt; 5; i++)<br />
     {<br />
-        o_id = instance_create_layer(x + (128 * i), y, &quot;Instances&quot;, obj_BridgePart);<br />
-        physics_fixture_bind(fix, o_id);<br />
-        if (i &gt; 0 &amp;&amp; i &lt; 4)<br />
+        _o_id = instance_create_layer(x + (128 * i), y, &quot;Instances&quot;, obj_bridge_part);<br />
+        _o_id.fix_bound = physics_fixture_bind(_fix, _o_id);<br />
+        if (i &gt; 0)<br />
         {<br />
-            physics_joint_weld_create(p_id, o_id, x + (128 * i) - 64, y, 0, 10, 12, true);<br />
+            physics_joint_weld_create(_p_id, _o_id, x + (128 * i) - 64, y, 0, 10, 12, true);<br />
         }<br />
-        p_id = o_id;<br />
+        _p_id = _o_id;<br />
     }<br />
-    physics_fixture_delete(fix);</p>
-  <p>The above code will create a fixture, then use a loop to create a number of instances, binding the fixture to each new instance and then joining them all together using a weld joint. Finally the fixture is deleted from memory.</p>
+    physics_fixture_delete(_fix);</p>
+  <p class="code_heading">Destroy Event</p>
+  <p class="code">with(obj_bridge_part)<br />
+    {<br />
+        physics_remove_fixture(id, fix_bound);<br />
+        instance_destroy();<br />
+    }</p>
+  <p>The above code shows how to use a weld joint to connect multiple physics instances.</p>
+  <p>In the Create event, a fixture is first created using and its shape is set to a 128 x 64 box shape. Then, a number of instances of an object <span class="inline2">obj_bridge_part</span> are created in a <span class="inline2"><a data-xref="{title}" href="../../../GML_Overview/Language_Features/for.htm">for</a></span> loop. The fixture is bound to each new instance using <span class="inline3_func"><a data-xref="{title}" href="../Fixtures/physics_fixture_bind.htm">physics_fixture_bind</a></span> and all instances except the first one are connected to the previous one using a weld joint created with <span class="inline3_func"><span data-field="title" data-format="default">physics_joint_weld_create</span></span>. Finally, the fixture is deleted from memory.</p>
+  <p>In the Destroy event, all instances of <span class="inline2">obj_bridge_part</span> are destroyed and the previously bound fixtures with them. Note that the weld joints aren&#39;t destroyed as this is done automatically by <span data-keyref="GameMaker Name">GameMaker</span>.</p>
   <p> </p>
   <p> </p>
   <div class="footer">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_wheel_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Physics/Joints/physics_joint_wheel_create.htm
@@ -19,7 +19,7 @@
   <p>This function creates a wheel joint between two physics instances.</p>
   <p>A wheel joint simply combines a piston and a revolute joint, like a wheel mounted on the shock absorber of a car. You specify the anchor point for the joint well as the two physics enabled instances to joint, and the first instance will act as the &quot;body&quot; for the joint, while the second will be the &quot;wheel&quot;, and be permitted to move freely around the joint axis. You can also set an axis vector, which is the imaginary line along which the joint will act as a &quot;spring&quot; permitting the wheel to bounce up and down along it as it encounters obstacles (much like the piston joint). The following image illustrates this:</p>
   <p><img alt="Wheel joint illustration" class="center" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Physics/wheel_joint_image.png" />If you choose to enable a motor, then the second instance will rotate around the anchor position, and you can set the maximum motor torque used to achieve the desired motor speed (N/m) as well as the speed at which the motor should turn. Since the wheel joint also has an axis along which it may move, you can set the oscillation frequency (in Hz) as well as the damping ratio for the joint - you may need to play with these values to fine tune them and it is recommended that you start off with smaller values and increment them until you get the effect that you desire.</p>
-  <p>As with all the joints, if you set the &quot;col&quot; value to <span class="inline">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events, however if it is set to <span class="inline">false</span>, they will not collide no matter what.</p>
+  <p>As with all the joints, if you set the <span class="inline2">col</span> value to <span class="inline2">true</span> then the two instances can interact and collide with each other but <i>only</i> if they have collision events. If it is set to <span class="inline2">false</span>, however, they will not collide no matter what.</p>
   <p> </p>
   <h4>Syntax:</h4>
   <p class="code"><span data-field="title" data-format="default">physics_joint_wheel_create</span>(inst1, inst2, anchor_x, anchor_y, axis_x, axis_y, enableMotor, max_motor_torque, motor_speed, freq_hz, damping_ratio, col)</p>
@@ -63,12 +63,12 @@
       <tr>
         <td>enableMotor</td>
         <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
-        <td>Whether the motor should be active (true) or not (false)</td>
+        <td>Whether the motor should be active (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
       <tr>
         <td>max_motor_torque</td>
         <td><span data-keyref="Type_Real"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
-        <td>Sets the maximum motor torque used to achieve the desired motor speed (in newton per meter)</td>
+        <td>The maximum motor torque used to achieve the desired motor speed (in newton per meter)</td>
       </tr>
       <tr>
         <td>motor_speed</td>
@@ -88,7 +88,7 @@
       <tr>
         <td>col</td>
         <td><span data-keyref="Type_Constant_Colour"><a href="../../Drawing/Colour_And_Alpha/Colour_And_Alpha.htm" target="_blank">Colour</a></span></td>
-        <td>Whether the two instances can collide (true) or not (false)</td>
+        <td>Whether the two instances can collide (<span class="inline2">true</span>) or not (<span class="inline2">false</span>)</td>
       </tr>
     </tbody>
   </table>
@@ -110,15 +110,14 @@
   <p>The above code creates and defines two new fixtures. These are then bound to the calling instance and a new instance that is created before having a wheel joint applied to connect them, after which the fixtures are deleted from memory.</p>
   <p> </p>
   <p> </p>
-  <p> </p>
   <div class="footer">
     <div class="buttons">
       <div class="clear">
-        <div style="float:left">Back: <a href="Joints.htm">Joints</a></div>
-        <div style="float:right">Next: <a href="physics_joint_weld_create.htm">physics_joint_weld_create</a></div>
+        <div style="float:left">Back: <a data-xref="{title}" href="Joints.htm">Joints</a></div>
+        <div style="float:right">Next: <a data-xref="{title}" href="physics_joint_weld_create.htm">physics_joint_weld_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 physics_joint_wheel_create

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_shuffle_ext.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_shuffle_ext.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>array_shuffle_ext</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" type="text/css" href="../../../assets/css/default.css" />
   <script src="../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="" />
@@ -33,18 +33,18 @@
       </tr>
       <tr>
         <td>array</td>
-        <td><span data-keyref="Type_Array"><a href="../../../../GameMaker_Language/GML_Overview/Arrays.htm" target="_blank">Array</a></span></td>
+        <td><span data-keyref="Type_Array"><a href="../../GML_Overview/Arrays.htm" target="_blank">Array</a></span></td>
         <td>The array to shuffle</td>
       </tr>
       <tr>
         <td>offset</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-keyref="Type_Real"><a href="../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
         <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The offset, or starting index, in the array to start shuffling. Defaults to 0. Setting a negative value will count from the end of the array. The starting index will then be <span class="inline2">array_length(array) + offset</span>. See: <a data-xref="{text}" href="Array_Functions.htm#offset_and_length">Offset And Length</a></td>
       </tr>
       <tr>
         <td>length</td>
-        <td><span data-keyref="Type_Real"><a href="../../../../GameMaker_Language/GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
-        <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The number of elements to shuffle. Defaults to <span class="inline2">(array_length(array) - 1</span>. See: <a data-xref="{text}" href="Array_Functions.htm#offset_and_length">Offset And Length</a></td>
+        <td><span data-keyref="Type_Real"><a href="../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td><span data-conref="../../../assets/snippets/Tag_optional.hts"> </span> The number of elements to shuffle. Defaults to <span class="inline2">array_length(array)</span>. See: <a data-xref="{text}" href="Array_Functions.htm#offset_and_length">Offset And Length</a></td>
       </tr>
     </tbody>
   </table>
@@ -66,7 +66,7 @@
         <div>Next: <a data-xref="{title}" href="array_create.htm">array_create</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 array_shuffle_ext

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/handle.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/handle.htm
@@ -16,7 +16,7 @@
 <body>
   <h1><span data-field="title" data-format="default">handle_parse</span></h1>
   <p>This function parses a string to create a <a href="../../GML_Overview/Data_Types.htm">handle reference</a>.</p>
-  <p>A handle is represented in a string with this format: <span data-conref="../../../assets/snippets/Handle_Format.hts"> </span> . Whether a handle is represented as an ID or as a name depends on the internal representation of the type.</p>
+  <p>A handle is represented in a string with this format: <span data-conref="../../../assets/snippets/Handle_Format.hts"> </span>. Whether a handle is represented as an ID or as a name depends on the internal representation of the type.</p>
   <p><span data-conref="../../../assets/snippets/Handle_Invalid.hts"> </span></p>
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> You can use <span class="inline3_func"><a data-xref="{title}" href="../Strings/string.htm">string</a></span> to get the string representation of a handle and <span class="inline3_func"><a data-xref="{title}" href="real.htm">real</a></span> to get the index number that it holds.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/handle.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/handle.htm
@@ -16,12 +16,12 @@
 <body>
   <h1><span data-field="title" data-format="default">handle_parse</span></h1>
   <p>This function parses a string to create a <a href="../../GML_Overview/Data_Types.htm">handle reference</a>.</p>
-  <p>A handle is represented in a string with this format: <span data-conref="../../../assets/snippets/Handle_Format.hts"> </span>.</p>
+  <p>A handle is represented in a string with this format: <span data-conref="../../../assets/snippets/Handle_Format.hts"> </span> . Whether a handle is represented as an ID or as a name depends on the internal representation of the type.</p>
   <p><span data-conref="../../../assets/snippets/Handle_Invalid.hts"> </span></p>
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> You can use <span class="inline3_func"><a data-xref="{title}" href="../Strings/string.htm">string</a></span> to get the string representation of a handle and <span class="inline3_func"><a data-xref="{title}" href="real.htm">real</a></span> to get the index number that it holds.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">handle_parse</span>(value_string);</p>
+  <p class="code"><span data-field="title" data-format="default">handle_parse</span>(value_string)</p>
   <table>
     <colgroup>
       <col />
@@ -48,16 +48,16 @@
   <h4>Example:</h4>
   <p class="code">sprite = spr_player;<br />
     handle_as_string = string(sprite);<br />
-    h = <span data-field="title" data-format="default">handle_parse</span>(handle_as_string);<br />
+    handle_from_string = <span data-field="title" data-format="default">handle_parse</span>(handle_as_string);<br />
     <br />
     show_debug_message($&quot;{sprite} ({typeof(sprite)})&quot;);<br />
     show_debug_message($&quot;{handle_as_string} ({typeof(handle_as_string)})&quot;);<br />
-    show_debug_message($&quot;{h} ({typeof(h)})&quot;);
+    show_debug_message($&quot;{handle_from_string} ({typeof(handle_from_string)})&quot;);
   </p>
-  <p>The code above converts the handle of a sprite named <span class="inline2">spr_player</span> to its string representation (<span class="inline2">handle_as_string</span>), and then back into a handle (<span class="inline2">h</span>). It then outputs each of the created instance variables in a debug message, along with its type. This prints the following:</p>
-  <p class="code_plain">ref sprite 0 (ref)<br />
-    ref sprite (string)<br />
-    ref sprite 0 (ref)</p>
+  <p>The code above converts the handle of a sprite named <span class="inline2">spr_player</span> to its string representation (<span class="inline2">handle_as_string</span>), and then back into a handle (<span class="inline2">handle_from_string</span>). It then outputs each of the created instance variables in a debug message, along with its type. This prints the following:</p>
+  <p class="code_plain">ref sprite spr_player (ref)<br />
+    ref sprite spr_player (string)<br />
+    ref sprite spr_player (ref)</p>
   <p>You can see that the original reference is converted into a string, which is then parsed back as a reference, which can again be used in functions just like the original reference.</p>
   <p>The values of the handle variables are implicitly converted to their string representation to display them.</p>
   <p> </p>
@@ -69,7 +69,7 @@
         <div>Next: <a data-xref="{title}" href="variable_instance_exists.htm">variable_instance_exists</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 handle_parse

--- a/Manual/contents/The_Asset_Editors/Code_Editor_Properties/Feather_Messages.htm
+++ b/Manual/contents/The_Asset_Editors/Code_Editor_Properties/Feather_Messages.htm
@@ -1281,6 +1281,33 @@
         show_debug_message(&quot;Here it is!&quot;);<br />
     }
   </p>
+  <h3>GM2018 - Potentially dangerous variable declaration.</h3>
+  <p>This warning message indicates that a declaration of a local variable inside a loop may cause unexpected results. Contrary to many other programming languages, GML does not scope local variables to the block level (indicated by the opening and closing curly braces <span class="inline2">{ }</span>) and also doesn&#39;t initialise them to a default value when they are only declared. This can lead to confusion as you might assume that the variable is re-declared and reset to a default value at each new iteration of the loop, though this is not what happens. At the end of the current loop iteration a local variable declared inside of it does <em>not</em> go out of scope, keeps existing and in subsequent iterations the variable will still hold the value it was last assigned.</p>
+  <h4>Example</h4>
+  <p class="code">for (var i = 0; i &lt; array_length(array); ++i)<br />
+    {<br />
+        var _elem; // GM2018<br />
+        if (i == 0)<br />
+            _elem = array[i];<br />
+        else if (i &lt; 5)<br />
+            _elem = array[i] * 2;<br />
+        <br />
+        add_loot_value(_elem);<br />
+    }</p>
+  <p>In the above code example, a local variable <span class="inline2">_elem</span> is declared inside a <span class="inline2"><a data-xref="{title}" href="../../GameMaker_Language/GML_Overview/Language_Features/for.htm">for</a></span> loop without being assigned an initial value. In the if / else statement that follows, a value is assigned to <span class="inline2">_elem</span> if the index of the loop is any value from 0 to 4 (inclusive). In the iteration where <span class="inline2">i == 5</span>, <span class="inline2">_elem</span> will not be explicitly assigned a value and still hold the last assigned value.</p>
+  <p>The issue can be fixed by moving the variable declaration outside of the loop&#39;s body so it can no longer appear as if the variable is reset at the start of each loop iteration. Additionally, the logic to assign a value to the variable needs to be extended to make sure a new value is always assigned at every new iteration of the loop, no matter the loop index.</p>
+  <p class="code">var _elem;<br />
+    for (var i = 0; i &lt; array_length(array); ++i)<br />
+    {<br />
+        if (i == 0)<br />
+            _elem = array[i];<br />
+        else if (i &lt; 5)<br />
+            _elem = array[i] * 2;<br />
+        else<br />
+            _elem = 0;  // Loop indices &gt;= 5<br />
+        <br />
+        add_loot_value(_elem);<br />
+    }</p>
   <h3>GM2019 - Not all code paths call draw_set_valign(fa_top) before the end of the script.</h3>
   <p>This warning message indicates that you changed the vertical text alignment to a value different from the default (<span class="inline2">fa_top</span>) but haven&#39;t changed it back afterwards.</p>
   <h4>Example</h4>

--- a/Manual/toc/Default.toc
+++ b/Manual/toc/Default.toc
@@ -2847,9 +2847,7 @@
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_create.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind_ext.htm" format="html" processing-role="normal"></page>
-          <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_set_collision_group.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_delete.htm" format="html" processing-role="normal"></page>
-          <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_remove_fixture.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_set_box_shape.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_set_circle_shape.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_set_edge_shape.htm" format="html" processing-role="normal"></page>
@@ -2864,12 +2862,14 @@
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_set_sensor.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_set_kinematic.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_set_awake.htm" format="html" processing-role="normal"></page>
+          <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_set_collision_group.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_get_friction.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_get_density.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_get_restitution.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_set_friction.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_set_density.htm" format="html" processing-role="normal"></page>
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_set_restitution.htm" format="html" processing-role="normal"></page>
+          <page href="../contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_remove_fixture.htm" format="html" processing-role="normal"></page>
         </book>
         <book href="../contents/GameMaker_Language/GML_Reference/Physics/Joints/Joints.htm" format="html" processing-role="normal">
           <page href="../contents/GameMaker_Language/GML_Reference/Physics/Joints/Physics_Joint_Constants.htm" format="html" processing-role="normal"></page>

--- a/Manual/variable/Default.var
+++ b/Manual/variable/Default.var
@@ -1548,6 +1548,13 @@
 		</keywords>
 	</topicmeta>
 </keydef>
+<keydef keys="Type_ID_PhyFixtureBound">
+	<topicmeta>
+		<keywords>
+			<keyword>&lt;a target=&quot;_blank&quot; href=&quot;contents/GameMaker_Language/GML_Reference/Physics/Fixtures/physics_fixture_bind.htm&quot;&gt;Physics Bound Fixture ID&lt;/a&gt;</keyword>
+		</keywords>
+	</topicmeta>
+</keydef>
 <keydef keys="Type_ID_Physics_Joint">
 	<topicmeta>
 		<keywords>


### PR DESCRIPTION
This PR has manual changes for the following:

* Added message for missing GM2018 (https://github.com/YoYoGames/GameMaker-Bugs/issues/13482)
* Physics Fixtures and Joints docs changes:
  * Weld joint angle is in degrees (https://github.com/YoYoGames/GameMaker-Bugs/issues/14221)
  * Different manual types for regular and "bound" fixtures
  * `physics_remove_fixture()` can also take an object ID
  * Code example updates and various other updates on the pages
* Various changes and fixes:
  * https://github.com/YoYoGames/GameMaker-Bugs/issues/14241
  * https://github.com/YoYoGames/GameMaker-Bugs/issues/13783