### PR TITLE
layer_sequence_blend() and layer_sequence_alpha(), built-in code snippets can be overridden, flexpanel_calculate_layout() dirty parameter

### DIFF
--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/Sequence_Layers.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/Sequence_Layers.htm
@@ -21,32 +21,43 @@
   <h2 id="func_ref">Function Reference</h2>
   <h3 id="func_ref_general">General</h3>
   <ul class="colour">
-    <li><a href="layer_sequence_exists.htm">layer_sequence_exists</a></li>
-    <li><a href="layer_sequence_create.htm">layer_sequence_create</a></li>
-    <li><a href="layer_sequence_destroy.htm">layer_sequence_destroy</a></li>
-    <li><a href="layer_sequence_x.htm">layer_sequence_x</a></li>
-    <li><a href="layer_sequence_y.htm">layer_sequence_y</a></li>
-    <li><a href="layer_sequence_angle.htm">layer_sequence_angle</a></li>
-    <li><a href="layer_sequence_xscale.htm">layer_sequence_xscale</a></li>
-    <li><a href="layer_sequence_yscale.htm">layer_sequence_yscale</a></li>
-    <li><a href="layer_sequence_headpos.htm">layer_sequence_headpos</a></li>
-    <li><a href="layer_sequence_headdir.htm">layer_sequence_headdir</a></li>
-    <li><a href="layer_sequence_pause.htm">layer_sequence_pause</a></li>
-    <li><a href="layer_sequence_play.htm">layer_sequence_play</a></li>
-    <li><a href="layer_sequence_speedscale.htm">layer_sequence_speedscale</a></li>
-    <li><a href="layer_sequence_get_x.htm">layer_sequence_get_x</a></li>
-    <li><a href="layer_sequence_get_y.htm">layer_sequence_get_y</a></li>
-    <li><a href="layer_sequence_get_angle.htm">layer_sequence_get_angle</a></li>
-    <li><a href="layer_sequence_get_xscale.htm">layer_sequence_get_xscale</a></li>
-    <li><a href="layer_sequence_get_yscale.htm">layer_sequence_get_yscale</a></li>
-    <li><a href="layer_sequence_get_headpos.htm">layer_sequence_get_headpos</a></li>
-    <li><a href="layer_sequence_get_headdir.htm">layer_sequence_get_headdir</a></li>
-    <li><a href="layer_sequence_get_speedscale.htm">layer_sequence_get_speedscale</a></li>
-    <li><a href="layer_sequence_get_length.htm">layer_sequence_get_length</a></li>
-    <li><a href="layer_sequence_get_instance.htm">layer_sequence_get_instance</a></li>
-    <li><a href="layer_sequence_get_sequence.htm">layer_sequence_get_sequence</a></li>
-    <li><a href="layer_sequence_is_paused.htm">layer_sequence_is_paused</a></li>
-    <li><a href="layer_sequence_is_finished.htm">layer_sequence_is_finished</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_exists.htm">layer_sequence_exists</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_create.htm">layer_sequence_create</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_destroy.htm">layer_sequence_destroy</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_length.htm">layer_sequence_get_length</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_instance.htm">layer_sequence_get_instance</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_sequence.htm">layer_sequence_get_sequence</a></li>
+  </ul>
+  <h3 id="func_ref_transform">Transform</h3>
+  <ul class="colour">
+    <li><a data-xref="{title}" href="layer_sequence_x.htm">layer_sequence_x</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_y.htm">layer_sequence_y</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_angle.htm">layer_sequence_angle</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_xscale.htm">layer_sequence_xscale</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_yscale.htm">layer_sequence_yscale</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_x.htm">layer_sequence_get_x</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_y.htm">layer_sequence_get_y</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_angle.htm">layer_sequence_get_angle</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_xscale.htm">layer_sequence_get_xscale</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_yscale.htm">layer_sequence_get_yscale</a></li>
+  </ul>
+  <h3 id="func_ref_playback">Playback</h3>
+  <ul class="colour">
+    <li><a data-xref="{title}" href="layer_sequence_play.htm">layer_sequence_play</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_pause.htm">layer_sequence_pause</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_headpos.htm">layer_sequence_headpos</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_headdir.htm">layer_sequence_headdir</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_speedscale.htm">layer_sequence_speedscale</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_headpos.htm">layer_sequence_get_headpos</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_headdir.htm">layer_sequence_get_headdir</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_get_speedscale.htm">layer_sequence_get_speedscale</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_is_paused.htm">layer_sequence_is_paused</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_is_finished.htm">layer_sequence_is_finished</a></li>
+  </ul>
+  <h3 id="func_ref_colour_alpha">Colour and Alpha</h3>
+  <ul class="colour">
+    <li><a data-xref="{title}" href="layer_sequence_blend.htm">layer_sequence_blend</a></li>
+    <li><a data-xref="{title}" href="layer_sequence_alpha.htm">layer_sequence_alpha</a></li>
   </ul>
   <ul class="colour">
   </ul>
@@ -60,7 +71,7 @@
         <div style="float:right">Next: <a data-xref="{title}" href="../Text_Functions/Text_Elements.htm">Text Elements</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 Sequence Layers

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_alpha.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_alpha.htm
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>layer_sequence_alpha</title>
+  <meta name="generator" content="Adobe RoboHelp 2022" />
+  <link rel="stylesheet" type="text/css" href="../../../../../assets/css/default.css" />
+  <script src="../../../../../assets/scripts/main_script.js" type="module"></script>
+  <meta name="rh-authors" content="" />
+  <meta name="topic-comment" content="" />
+  <meta name="rh-index-keywords" content="layer_sequence_alpha" />
+  <meta name="search-keywords" content="layer_sequence_alpha" />
+  <meta name="template" content="assets/masterpages/Manual_Keyword_Page.htt" />
+</head>
+<body>
+  <h1><span data-field="title" data-format="default">layer_sequence_alpha</span></h1>
+  <p>This function sets the alpha of the given sequence element.</p>
+  <p> </p>
+  <h4>Syntax:</h4>
+  <p class="code"><span data-field="title" data-format="default">layer_sequence_alpha</span>(sequence_element_id, alpha)</p>
+  <table>
+    <colgroup>
+      <col />
+      <col />
+      <col />
+    </colgroup>
+    <tbody>
+      <tr>
+        <th>Argument</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td>sequence_element_id</td>
+        <td><span data-keyref="Type_ID_Element_Sequence"><a href="layer_sequence_create.htm" target="_blank">Sequence Element ID</a></span></td>
+        <td>The ID of the sequence element</td>
+      </tr>
+      <tr>
+        <td>alpha</td>
+        <td><span data-keyref="Type_Real"><a href="../../../../GML_Overview/Data_Types.htm" target="_blank">Real</a></span></td>
+        <td>The alpha to use for the sequence element (a value from 0 to 1)</td>
+      </tr>
+    </tbody>
+  </table>
+  <p> </p>
+  <h4>Returns:</h4>
+  <p class="code"><span data-keyref="Type_Void">N/A</span></p>
+  <p> </p>
+  <h4>Example:</h4>
+  <p class="code"><span data-field="title" data-format="default">layer_sequence_alpha</span>(my_sequence_element, 0.6);</p>
+  <p>This code sets the alpha value of the sequence element stored in a variable <span class="inline2">my_sequence_element</span> to <span class="inline2">0.6</span>.</p>
+  <p> </p>
+  <p> </p>
+  <div class="footer">
+    <div class="buttons">
+      <div class="clear">
+        <div>Back: <a data-xref="{title}" href="Sequence_Layers.htm">Sequence Elements</a></div>
+        <div>Next: <a data-xref="{title}" href="layer_sequence_exists.htm">layer_sequence_exists</a></div>
+      </div>
+    </div>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
+  </div>
+  <!-- KEYWORDS
+layer_sequence_alpha
+-->
+  <!-- TAGS
+layer_sequence_alpha
+-->
+</body>
+</html>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_blend.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_blend.htm
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>layer_sequence_blend</title>
+  <meta name="generator" content="Adobe RoboHelp 2022" />
+  <link rel="stylesheet" type="text/css" href="../../../../../assets/css/default.css" />
+  <script src="../../../../../assets/scripts/main_script.js" type="module"></script>
+  <meta name="rh-authors" content="" />
+  <meta name="topic-comment" content="" />
+  <meta name="rh-index-keywords" content="layer_sequence_blend" />
+  <meta name="search-keywords" content="layer_sequence_blend" />
+  <meta name="template" content="assets/masterpages/Manual_Keyword_Page.htt" />
+</head>
+<body>
+  <h1><span data-field="title" data-format="default">layer_sequence_blend</span></h1>
+  <p>This function sets the blend colour of the given sequence element.</p>
+  <p> </p>
+  <h4>Syntax:</h4>
+  <p class="code"><span data-field="title" data-format="default">layer_sequence_blend</span>(sequence_element_id, blend)</p>
+  <table>
+    <colgroup>
+      <col />
+      <col />
+      <col />
+    </colgroup>
+    <tbody>
+      <tr>
+        <th>Argument</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td>sequence_element_id</td>
+        <td><span data-keyref="Type_ID_Element_Sequence"><a href="layer_sequence_create.htm" target="_blank">Sequence Element ID</a></span></td>
+        <td>The ID of the sequence element</td>
+      </tr>
+      <tr>
+        <td>blend</td>
+        <td><span data-keyref="Type_Constant_Colour"><a href="../../../Drawing/Colour_And_Alpha/Colour_And_Alpha.htm" target="_blank">Colour</a></span></td>
+        <td>The blend colour to use for the sequence element</td>
+      </tr>
+    </tbody>
+  </table>
+  <p> </p>
+  <h4>Returns:</h4>
+  <p class="code"><span data-keyref="Type_Void">N/A</span></p>
+  <p> </p>
+  <h4>Example:</h4>
+  <p class="code">var _arr_elements = layer_get_all_elements(&quot;Assets&quot;);<br />
+    for(var i = 0;i &lt; array_length(_arr_elements);i++)<br />
+    {<br />
+        var _element = _arr_elements[i];<br />
+        if (layer_get_element_type(_element) != layerelementtype_sequence) { continue; }<br />
+        <br />
+        <span data-field="title" data-format="default">layer_sequence_blend</span>(_arr_elements[i], c_red);<br />
+    }</p>
+  <p>This code sets the blend colour of all sequence elements on an existing layer named <span class="inline2">&quot;Assets&quot;</span> to red.</p>
+  <p> </p>
+  <p> </p>
+  <div class="footer">
+    <div class="buttons">
+      <div class="clear">
+        <div>Back: <a data-xref="{title}" href="Sequence_Layers.htm">Sequence Elements</a></div>
+        <div>Next: <a data-xref="{title}" href="layer_sequence_alpha.htm">layer_sequence_alpha</a></div>
+      </div>
+    </div>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
+  </div>
+  <!-- KEYWORDS
+layer_sequence_blend
+-->
+  <!-- TAGS
+layer_sequence_blend
+-->
+</body>
+</html>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_destroy.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_destroy.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>layer_sequence_destroy</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../../../assets/css/default.css" type="text/css" />
   <script src="../../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -31,7 +31,7 @@
       </tr>
       <tr>
         <td>sequence_element_id</td>
-        <td><span data-keyref="Type_ID_Element_Sequence"><a href="../../../../../../GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_create.htm" target="_blank">Sequence Element ID</a></span></td>
+        <td><span data-keyref="Type_ID_Element_Sequence"><a href="layer_sequence_create.htm" target="_blank">Sequence Element ID</a></span></td>
         <td>The unique ID value of the sequence element to target</td>
       </tr>
     </tbody>
@@ -44,7 +44,7 @@
   <p class="code">var a = layer_get_all_elements(layer);<br />
     for (var i = 0; i &lt; array_length(a); i++)<br />
     {<br />
-        if layer_get_element_type(a[i]) == layerelementtype_sequence<br />
+        if (layer_get_element_type(a[i]) == layerelementtype_sequence)<br />
         {<br />
             <span data-field="title" data-format="default">layer_sequence_destroy</span>(a[i]);<br />
         }<br />
@@ -55,7 +55,7 @@
     var track_struct;<br />
     for (var i = 0; i &lt; array_length(a); i++)<br />
     {<br />
-        if layer_get_element_type(a[i]) == layerelementtype_sequence<br />
+        if (layer_get_element_type(a[i]) == layerelementtype_sequence)<br />
         {<br />
             var ins = layer_sequence_get_instance(a[i]);<br />
             track_struct = ins.activeTracks[0];<br />
@@ -73,7 +73,7 @@
         <div style="float:right">Next: <a href="layer_sequence_x.htm">layer_sequence_x</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2022 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 layer_sequence_destroy

--- a/Manual/contents/GameMaker_Language/GML_Reference/Buffers/buffer_load_async.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Buffers/buffer_load_async.htm
@@ -19,10 +19,10 @@
   <p>The &quot;offset&quot; defines the start position within the buffer for loading (in bytes), and the &quot;size&quot; is the size of the buffer area to be loaded from that offset onwards (also in bytes). You can supply a value of -1 for the size argument to load the entire buffer. Note that the function will load from a &quot;default&quot; folder (unless you are using an <a href="buffer_async_group_begin.htm">async group</a>, then the name of the group replaces &quot;default&quot;), which does <i>not</i> need to be included as part of the file path you provide. This folder will be created if it doesn&#39;t exist or when you save a file using <span class="inline3_func"><a data-xref="{title}" href="buffer_save_async.htm">buffer_save_async</a></span>.</p>
   <p>The function returns a unique ID value which can then be used in the <a href="../../../The_Asset_Editors/Object_Properties/Async_Events/Save_Load.htm">Save / Load Asynchronous event</a> to check the <span class="inline2"><a data-xref="{title}" href="../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span>&#39;s ID value, as shown in the extended example below. The <span class="inline2"><a data-xref="{title}" href="../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm">async_load</a></span> map in the event will have the following two key/value pairs:</p>
   <ul class="colour">
-    <li><b>&quot;id&quot;: </b>the ID of the async function as returned by the save function.</li>
-    <li><b>&quot;status&quot;: </b>will return <span class="inline2">true</span> if the data was loaded correctly, <span class="inline2">false</span> otherwise.</li>
+    <li><b>&quot;id&quot;: </b>the ID of the async request as returned by the save function.</li>
+    <li><b>&quot;status&quot;: </b>will hold <span class="inline2">true</span> if the data was loaded correctly, <span class="inline2">false</span> otherwise.</li>
   </ul>
-  <p class="note"><span class="note">NOTE</span> On <b>HTML5</b>, this is the preferred method for loading a file if you are loading from a server and not local storage, as loading synchronously has been deprecated on most browsers and will eventually be obsoleted.</p>
+  <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> On <b>HTML5</b>, this is the preferred method for loading a file if you are loading from a server and not local storage, as loading synchronously has been deprecated on most browsers and will eventually be obsoleted.</p>
   <p>Please read the <span class="inline3_func"><a data-xref="{title}" href="buffer_load.htm">buffer_load</a></span> page for platform-specific notes.</p>
   <p> </p>
   <h4>Syntax:</h4>
@@ -81,7 +81,7 @@
         <div style="float:right">Next: <a href="buffer_load_partial.htm">buffer_load_partial</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 buffer_load_async

--- a/Manual/contents/GameMaker_Language/GML_Reference/Buffers/buffer_save_async.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Buffers/buffer_save_async.htm
@@ -24,8 +24,8 @@
     <font face="menlo, consolas, monospace"><span style="font-size: 17px;"> </span></font>map in the event will have the following two key/value pairs:
   </p>
   <ul>
-    <li><b>&quot;id&quot;: </b>the ID of the async function as returned by the save function.</li>
-    <li><b>&quot;status&quot;: </b>will return <span class="inline2">true</span> if the data was saved correctly, and <span class="inline2">false</span> otherwise.</li>
+    <li><b>&quot;id&quot;: </b>the ID of the async request as returned by the save function.</li>
+    <li><b>&quot;status&quot;: </b>will hold <span class="inline2">true</span> if the data was saved correctly, and <span class="inline2">false</span> otherwise.</li>
   </ul>
   <p>Note that you can save out multiple buffers in one by calling this function multiple times between calls to <span class="inline3_func"><a data-xref="{title}" href="buffer_async_group_begin.htm">buffer_async_group_begin</a></span> and <span class="inline3_func"><a data-xref="{title}" href="buffer_async_group_end.htm">buffer_async_group_end</a></span>
     <font face="menlo, consolas, monospace"><span style="font-size: 17px;"> </span></font>(see those functions for further information on this).
@@ -88,7 +88,7 @@
         <div style="float:right">Next: <a href="buffer_load.htm">buffer_load</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2025 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 buffer_save_async

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Colour_And_Alpha/Colour_And_Alpha.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Colour_And_Alpha/Colour_And_Alpha.htm
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>Colour And Alpha</title>
-  <meta name="generator" content="Adobe RoboHelp 2020" />
+  <meta name="generator" content="Adobe RoboHelp 2022" />
   <link rel="stylesheet" href="../../../../assets/css/default.css" type="text/css" />
   <script src="../../../../assets/scripts/main_script.js" type="module"></script>
   <meta name="rh-authors" content="Mark Alexander" />
@@ -26,7 +26,7 @@
     </colgroup>
     <tbody>
       <tr>
-        <th colspan="3"><span data-keyref="Type_Constant_Colour"><a href="../../../../../GameMaker_Language/GML_Reference/Drawing/Colour_And_Alpha/Colour_And_Alpha.htm" target="_blank">Colour</a></span></th>
+        <th colspan="3"><span data-keyref="Type_Constant_Colour"><a href="Colour_And_Alpha.htm" target="_blank">Colour</a></span></th>
       </tr>
       <tr>
         <th>Constant</th>
@@ -139,7 +139,7 @@
   <p class="code">col = #<strong>11CCFF</strong>;</p>
   <p>This is the same colour as shown in the previous code block, only the <span class="inline2">RR</span> and <span class="inline2">BB</span> values are swapped to match the format.</p>
   <p class="note"><span class="note">NOTE</span> GML also supports the <span class="inline2">$AABBGGRR</span> format (with the alpha hex value in the beginning) however most GML colour functions will only be able to make use of the colour part and ignore the alpha.</p>
-  <p class="note"><span data-conref="../../../../assets/snippets/Tag_important.hts"> </span> Avoid using hex codes (starting with <span class="inline2">$</span> or <span class="inline2">#</span>) after an opening bracket <span class="inline2">[</span>, as GameMaker might interpret that as an <a href="../../../GML_Overview/Accessors.htm">accessor</a>.</p>
+  <p class="note"><span data-conref="../../../../assets/snippets/Tag_important.hts"> </span> Avoid using hex codes (starting with <span class="inline2">$</span> or <span class="inline2">#</span>) after an opening bracket <span class="inline2">[</span>, as <span data-keyref="GameMaker Name">GameMaker</span> might interpret that as an <a href="../../../GML_Overview/Accessors.htm">accessor</a>.</p>
   <h2>Functions</h2>
   <p>The following functions can be used to get the component hues, compound hue, saturation and luminosity of a selected colour as well as the alpha and other properties:</p>
   <ul class="colour">
@@ -178,7 +178,7 @@
         <div style="float:right">Next: <a href="../GPU_Control/GPU_Control.htm">GPU Control</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2023 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 Colour And Alpha

--- a/Manual/contents/GameMaker_Language/GML_Reference/Flex_Panels/Function_Reference/flexpanel_calculate_layout.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Flex_Panels/Function_Reference/flexpanel_calculate_layout.htm
@@ -21,9 +21,10 @@
   <p>You can see these dimensions as the final resolution of the canvas where your layout is active, e.g. when making a full-screen interface, these dimensions would be equal to your game window&#39;s size, or for an interface that is housed inside a small window within your game, they would be the dimensions of that window.</p>
   <p>The width or height can be <span class="inline2"><span data-keyref="Type_Undefined"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">undefined</a></span></span>, in which case it will extend indefinitely.</p>
   <p>You must choose whether the <a href="../Flex_Panels_Styling.htm#layout">layout direction</a> is left-to-right or right-to-left by passing a <span data-keyref="Type_Const_FlexPanel_Direction"><a href="Styling_Functions/flexpanel_node_style_set_direction.htm" target="_blank">Flex Panel Layout Direction Constant</a></span>.</p>
+  <p>You can specify if you want to call any <a href="flexpanel_node_set_measure_function.htm">measure functions</a> when calculating the layout using the optional <span class="inline2">dirty</span> parameter. These functions are called by default, unless you set this parameter to <span class="inline2">false</span>.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">flexpanel_calculate_layout</span>(root, width, height, [direction])</p>
+  <p class="code"><span data-field="title" data-format="default">flexpanel_calculate_layout</span>(root, width, height, direction, [dirty])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Flex_Panels/Function_Reference/flexpanel_calculate_layout.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Flex_Panels/Function_Reference/flexpanel_calculate_layout.htm
@@ -23,7 +23,7 @@
   <p>You must choose whether the <a href="../Flex_Panels_Styling.htm#layout">layout direction</a> is left-to-right or right-to-left by passing a <span data-keyref="Type_Const_FlexPanel_Direction"><a href="Styling_Functions/flexpanel_node_style_set_direction.htm" target="_blank">Flex Panel Layout Direction Constant</a></span>.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">flexpanel_calculate_layout</span>(root, width, height, direction)</p>
+  <p class="code"><span data-field="title" data-format="default">flexpanel_calculate_layout</span>(root, width, height, [direction])</p>
   <table>
     <colgroup>
       <col />
@@ -56,6 +56,11 @@
         <td><span data-keyref="Type_Const_FlexPanel_Direction"><a href="Styling_Functions/flexpanel_node_style_set_direction.htm" target="_blank">Flex Panel Layout Direction Constant</a></span></td>
         <td>The direction to use for all nodes</td>
       </tr>
+      <tr>
+        <td>dirty</td>
+        <td><span data-keyref="Type_Bool"><a href="../../../GML_Overview/Data_Types.htm" target="_blank">Boolean</a></span></td>
+        <td><span data-conref="../../../../assets/snippets/Tag_optional.hts"> </span> Whether to force calling any measure functions (defaults to <span class="inline2">true</span>)</td>
+      </tr>
     </tbody>
   </table>
   <p> </p>
@@ -74,7 +79,7 @@
         <div>Next: <a data-xref="{title}" href="flexpanel_node_set_name.htm">flexpanel_node_set_name</a></div>
       </div>
     </div>
-    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2024 All Rights Reserved</span></h5>
+    <h5><span data-keyref="Copyright Notice">© Copyright YoYo Games Ltd. 2026 All Rights Reserved</span></h5>
   </div>
   <!-- KEYWORDS
 flexpanel_calculate_layout

--- a/Manual/contents/Settings/Building_via_Command_Line.htm
+++ b/Manual/contents/Settings/Building_via_Command_Line.htm
@@ -138,7 +138,7 @@
       </tr>
       <tr>
         <td><span class="inline">/packagetype</span></td>
-        <td>For the <span>GX</span>.games target, select the type of package to build, from: <span class="inline2">&quot;OperaGXPackage_Zip&quot;</span>, <span class="inline2">&quot;OperaGXPackage_Gamestrip&quot;</span>, or <span class="inline2">&quot;OperaGXPackage_Wallpaper&quot;</span></td>
+        <td>For the GX.games target, select the type of package to build, from: <span class="inline2">&quot;OperaGXPackage_Zip&quot;</span>, <span class="inline2">&quot;OperaGXPackage_Gamestrip&quot;</span>, or <span class="inline2">&quot;OperaGXPackage_Wallpaper&quot;</span></td>
       </tr>
       <tr>
         <td><span class="inline">/prefabs</span></td>
@@ -391,7 +391,7 @@
       </tr>
       <tr>
         <td style=""><span class="inline">Runtime Install [-version]</span></td>
-        <td style="">Installs the latest runtime from the given feed using the given <span class="inline">version</span> as a search filter; if that is not specified, it defaults to the latest version. It will get all the modules that the user has on their licence.</td>
+        <td style="">Installs the latest runtime from the given feed using the given <span class="inline">version</span> as a search filter; if no version is specified, it defaults to the latest version. If a version is specified and this version cannot be found, the command will fail with an error message. This command will get all the modules that the user has on their licence.</td>
       </tr>
       <tr>
         <td style=""><span class="inline">Runtime Verify [-folder=.]</span></td>

--- a/Manual/contents/The_Asset_Editors/Code_Editor_Properties/Code_Snippets.htm
+++ b/Manual/contents/The_Asset_Editors/Code_Editor_Properties/Code_Snippets.htm
@@ -55,7 +55,7 @@
     <li><strong>uuid</strong>: This must be replaced with a new UUID. You can use a <a href="https://www.uuidgenerator.net">UUID generator</a>.</li>
   </ul>
   <p>Note that no hotkeys can be assigned to <a data-xref="{title}" href="../The_Text_Editor.htm">Code Editor 2 (Beta)</a> snippets as they are inserted using <a data-xref="{title}" href="Feather_Features.htm">Code Completion</a>.</p>
-  <h3>Overriding built-in snippets</h3>
+  <h3>Overriding Built-in Snippets</h3>
   <p>You can override built-in snippets by adding a <span class="inline2">.tmSnippet</span> file with the name of the built-in snippet you want to override into your user directory, for example <span class="inline2">for.tmSnippet</span>. This can be used, for example, to redefine a code snippet so it uses a different coding style.</p>
   <h3>Snippet Syntax</h3>
   <p>The snippet content must follow a specific format where:</p>

--- a/Manual/contents/The_Asset_Editors/Code_Editor_Properties/Code_Snippets.htm
+++ b/Manual/contents/The_Asset_Editors/Code_Editor_Properties/Code_Snippets.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1>Code Snippets</h1>
+  <h1><span data-field="title" data-format="default">Code Snippets</span></h1>
   <p>A very handy tool you have at your disposal when editing your code is the use of <strong>Code Snippets</strong>.</p>
   <p>These are pre-made blocks of code you can insert into your code at any time. A snippet can have <em>placeholders</em>, where you can insert expressions while entering the snippet.</p>
   <h2>Using Snippets</h2>
@@ -55,6 +55,8 @@
     <li><strong>uuid</strong>: This must be replaced with a new UUID. You can use a <a href="https://www.uuidgenerator.net">UUID generator</a>.</li>
   </ul>
   <p>Note that no hotkeys can be assigned to <a data-xref="{title}" href="../The_Text_Editor.htm">Code Editor 2 (Beta)</a> snippets as they are inserted using <a data-xref="{title}" href="Feather_Features.htm">Code Completion</a>.</p>
+  <h3>Overriding built-in snippets</h3>
+  <p>You can override built-in snippets by adding a <span class="inline2">.tmSnippet</span> file with the name of the built-in snippet you want to override into your user directory, for example <span class="inline2">for.tmSnippet</span>. This can be used, for example, to redefine a code snippet so it uses a different coding style.</p>
   <h3>Snippet Syntax</h3>
   <p>The snippet content must follow a specific format where:</p>
   <ul class="colour">

--- a/Manual/toc/Default.toc
+++ b/Manual/toc/Default.toc
@@ -1534,29 +1534,31 @@
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_exists.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_create.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_destroy.htm" format="html" processing-role="normal"></page>
+            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_length.htm" format="html" processing-role="normal"></page>
+            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_instance.htm" format="html" processing-role="normal"></page>
+            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_sequence.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_x.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_y.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_angle.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_xscale.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_yscale.htm" format="html" processing-role="normal"></page>
-            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_headpos.htm" format="html" processing-role="normal"></page>
-            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_headdir.htm" format="html" processing-role="normal"></page>
-            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_pause.htm" format="html" processing-role="normal"></page>
-            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_play.htm" format="html" processing-role="normal"></page>
-            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_speedscale.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_x.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_y.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_angle.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_xscale.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_yscale.htm" format="html" processing-role="normal"></page>
+            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_play.htm" format="html" processing-role="normal"></page>
+            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_pause.htm" format="html" processing-role="normal"></page>
+            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_headpos.htm" format="html" processing-role="normal"></page>
+            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_headdir.htm" format="html" processing-role="normal"></page>
+            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_speedscale.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_headpos.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_headdir.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_speedscale.htm" format="html" processing-role="normal"></page>
-            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_length.htm" format="html" processing-role="normal"></page>
-            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_instance.htm" format="html" processing-role="normal"></page>
-            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_get_sequence.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_is_paused.htm" format="html" processing-role="normal"></page>
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_is_finished.htm" format="html" processing-role="normal"></page>
+            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_blend.htm" format="html" processing-role="normal"></page>
+            <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Sequence_Layers/layer_sequence_alpha.htm" format="html" processing-role="normal"></page>
           </book>
           <book href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Text_Functions/Text_Elements.htm" format="html" processing-role="normal">
             <page href="../contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/Text_Functions/layer_text_create.htm" format="html" processing-role="normal"></page>


### PR DESCRIPTION
This PR has changes to the manual for the following:

* https://github.com/YoYoGames/GameMaker-Bugs/issues/14404
* https://github.com/YoYoGames/GameMaker-Bugs/issues/10164
* https://github.com/YoYoGames/GameMaker-Bugs/issues/14420
* https://github.com/YoYoGames/GameMaker-Bugs/issues/14618
* Some small typo fixes for https://github.com/YoYoGames/GameMaker-Bugs/issues/14521