### PR TITLE
Fix typos with square braces in function syntax blocks that have optional arguments

### DIFF
--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Instances/instance_destroy.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Instances/instance_destroy.htm
@@ -29,7 +29,7 @@
   <p class="note"><span data-conref="../../../../assets/snippets/Tag_important.hts"> </span> This function does <strong>not</strong> destroy <a href="Deactivating_Instances/Deactivating_Instances.htm">deactivated instances</a>. You need to make sure that all instances you want to destroy are activated using the <a data-xref="{text}" href="Deactivating_Instances/Deactivating_Instances.htm#func_ref_instance_activation">Instance Activation</a> functions.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">instance_destroy</span>([id, execute_event_flag])</p>
+  <p class="code"><span data-field="title" data-format="default">instance_destroy</span>([id], [execute_event_flag])</p>
   <table>
     <tbody>
       <tr>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Data_Structures/DS_Grids/ds_grid_read.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Data_Structures/DS_Grids/ds_grid_read.htm
@@ -19,7 +19,7 @@
   <div data-conref="../../../../assets/snippets/Note_DS_Format_Changes.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">ds_grid_read</span>(index, string [, legacy])</p>
+  <p class="code"><span data-field="title" data-format="default">ds_grid_read</span>(index, string, [legacy])</p>
   <table>
     <tbody>
       <tr>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Data_Structures/DS_Grids/ds_grid_to_mp_grid.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Data_Structures/DS_Grids/ds_grid_to_mp_grid.htm
@@ -56,7 +56,7 @@
   </ul>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">ds_grid_to_mp_grid</span>(ds_grid, mp_grid[, func])</p>
+  <p class="code"><span data-field="title" data-format="default">ds_grid_to_mp_grid</span>(ds_grid, mp_grid, [func])</p>
   <table>
     <colgroup>
       <col/>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Data_Structures/DS_Lists/ds_list_read.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Data_Structures/DS_Lists/ds_list_read.htm
@@ -19,7 +19,7 @@
   <div data-conref="../../../../assets/snippets/Note_DS_Format_Changes.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">ds_list_read</span>(id, str [, legacy])</p>
+  <p class="code"><span data-field="title" data-format="default">ds_list_read</span>(id, str, [legacy])</p>
   <table>
     <tbody>
       <tr>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Data_Structures/DS_Queues/ds_queue_read.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Data_Structures/DS_Queues/ds_queue_read.htm
@@ -19,7 +19,7 @@
   <div data-conref="../../../../assets/snippets/Note_DS_Format_Changes.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">ds_queue_read</span>(id, str [, legacy])</p>
+  <p class="code"><span data-field="title" data-format="default">ds_queue_read</span>(id, str, [legacy])</p>
   <table>
     <tbody>
       <tr>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Data_Structures/DS_Stacks/ds_stack_read.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Data_Structures/DS_Stacks/ds_stack_read.htm
@@ -19,7 +19,7 @@
   <div data-conref="../../../../assets/snippets/Note_DS_Format_Changes.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">ds_stack_read</span>(id, str [, legacy])</p>
+  <p class="code"><span data-field="title" data-format="default">ds_stack_read</span>(id, str, [legacy])</p>
   <table>
     <tbody>
       <tr>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_button.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_button.htm
@@ -19,7 +19,7 @@
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Single_Column.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_button</span>(label, ref[, width, height])</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_button</span>(label, ref, [width], [height])</p>
   <p> </p>
   <table>
     <colgroup>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_drop_down.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_drop_down.htm
@@ -22,7 +22,7 @@
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Two_Columns.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_drop_down</span>(ref_or_array, specifier[, label])</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_drop_down</span>(ref_or_array, specifier, [label])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_section.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_section.htm
@@ -26,7 +26,7 @@
   </ul>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_section</span>(name [, open])</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_section</span>(name, [open])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_slider.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_slider.htm
@@ -21,7 +21,7 @@
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Two_Columns.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_slider</span>(ref_or_array, [minimum, maximum, label, step])</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_slider</span>(ref_or_array, [minimum], [maximum], [label], [step])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_slider_int.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_slider_int.htm
@@ -22,7 +22,7 @@
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Two_Columns.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_slider_int</span>(ref_or_array, [minimum, maximum, label, step])</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_slider_int</span>(ref_or_array, [minimum], [maximum], [label], [step])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_sprite.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_sprite.htm
@@ -21,7 +21,7 @@
   <div data-conref="../../../assets/snippets/Note_Debug_Control_Two_Columns.hts"> </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_sprite</span>(sprite_ref_or_array, image_index_ref_or_array, [label, width, height])</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_sprite</span>(sprite_ref_or_array, image_index_ref_or_array, [label], [width], [height])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_sprite_button.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_sprite_button.htm
@@ -19,7 +19,7 @@
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> This control isn&#39;t split into two columns but is shown in a single column.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_sprite_button</span>(ref, ref_sprite, ref_sprite_index[, width, height, xoffset, yoffset, width_sprite, height_sprite])</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_sprite_button</span>(ref, ref_sprite, ref_sprite_index, [width], [height], [xoffset], [yoffset], [width_sprite], [height_sprite])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_text_input.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_text_input.htm
@@ -29,7 +29,7 @@
   <p class="note"><span data-conref="../../../assets/snippets/Tag_note.hts"> </span> On Android, editing a text field will bring up the on-screen keyboard.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_text_input</span>(ref_or_array, [label, type])</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_text_input</span>(ref_or_array, [label], [type])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_view.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/dbg_view.htm
@@ -27,7 +27,7 @@
   </ul>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">dbg_view</span>(name, visible[, x, y, width, height])</p>
+  <p class="code"><span data-field="title" data-format="default">dbg_view</span>(name, visible, [x], [y], [width], [height])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_update_buffer_from_buffer.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_update_buffer_from_buffer.htm
@@ -25,7 +25,7 @@
   </ul>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">vertex_update_buffer_from_buffer</span>(dest_vbuff, dest_offset, src_buffer[, src_offset, src_size])</p>
+  <p class="code"><span data-field="title" data-format="default">vertex_update_buffer_from_buffer</span>(dest_vbuff, dest_offset, src_buffer, [src_offset], [src_size])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_update_buffer_from_vertex.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_update_buffer_from_vertex.htm
@@ -26,7 +26,7 @@
   </ul>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">vertex_update_buffer_from_vertex</span>(dest_vbuff, dest_vert, src_vbuff[, src_vert, src_vert_num])</p>
+  <p class="code"><span data-field="title" data-format="default">vertex_update_buffer_from_vertex</span>(dest_vbuff, dest_vert, src_vbuff, [src_vert], [src_vert_num])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Textures/texturegroup_set_mode.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Textures/texturegroup_set_mode.htm
@@ -32,7 +32,7 @@
   <p> </p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">texturegroup_set_mode</span>(explicit, [debug=false, default_sprite=-1])</p>
+  <p class="code"><span data-field="title" data-format="default">texturegroup_set_mode</span>(explicit, [debug=false], [default_sprite=-1])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Rollback/Rollback_Functions/rollback_create_game.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Rollback/Rollback_Functions/rollback_create_game.htm
@@ -24,7 +24,7 @@
   <p class="note"><span class="warning">WARNING</span> It is not recommended to set a default region in this function unless you are allowing the player to select it through a menu.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">rollback_create_game</span>(num_players, [enable_sync_test, region])</p>
+  <p class="code"><span data-field="title" data-format="default">rollback_create_game</span>(num_players, [enable_sync_test], [region])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Time_Sources/time_source_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Time_Sources/time_source_create.htm
@@ -60,7 +60,7 @@
   </div>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">time_source_create</span>(parent, period, units, callback, [args, repetitions, expiry_type])</p>
+  <p class="code"><span data-field="title" data-format="default">time_source_create</span>(parent, period, units, callback, [args], [repetitions], [expiry_type])</p>
   <table>
     <colgroup>
       <col />

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/ref_create.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/ref_create.htm
@@ -24,7 +24,7 @@
   <p class="note"><span data-conref="../../../assets/snippets/Tag_warning.hts"> </span> You <em>cannot</em> create references to <a data-xref="{title}" href="../../GML_Overview/Variables/Local_Variables.htm">Local Variables</a>, since they exist only temporarily and cannot be referenced.</p>
   <p> </p>
   <h4>Syntax:</h4>
-  <p class="code"><span data-field="title" data-format="default">ref_create</span>(dbgrefOrStruct, dbgrefOrIndex[, index])</p>
+  <p class="code"><span data-field="title" data-format="default">ref_create</span>(dbgrefOrStruct, dbgrefOrIndex, [index])</p>
   <table>
     <colgroup>
       <col />


### PR DESCRIPTION
This PR has documentation changes for the following :
https://github.com/YoYoGames/GameMaker-Manual/issues/416

It fixes things like
`instance_destroy([id, execute_event_flag])` --\> `instance_destroy([id], [execute_event_flag])`
and
`ds_grid_read(index, string [, legacy])` --\> `ds_grid_read(index, string, [legacy])`

This PR DOES NOT touches things like
`gpu_set_scissor(x_or_struct, [y, w, h])`
and things like
`shader_set_uniform_f(handle, value1 [, value2, value3, value4])`
Since i'm not sure whether ot not they were written like that intentionally .
I opened a sepparate issue for all these unresolved cases -
https://github.com/YoYoGames/GameMaker-Manual/issues/418

Note -
Use this regular expression in VSCode project-search for finding all rogue braces -
```
</span>.*\(.*\[[^\]\.]*,[^\[\.]*\]\)</p>
```